### PR TITLE
order api 추가 (#20)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "java.compile.nullAnalysis.mode": "disabled",
-    "java.configuration.updateBuildConfiguration": "automatic"
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.debug.settings.onBuildFailureProceed": true
 }

--- a/backend/src/main/java/cloud/weareithero/api/order/OrderController.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/OrderController.java
@@ -1,0 +1,44 @@
+package cloud.weareithero.api.order;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import cloud.weareithero.api.order.dto.OrderAddDTO;
+import cloud.weareithero.api.order.dto.OrderRequestDTO;
+import cloud.weareithero.api.order.service.OrderService;
+import cloud.weareithero.dto.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/order")
+@RequiredArgsConstructor
+public class OrderController implements OrderControllerDocs {
+
+  private final OrderService OrderService;
+  
+  @PostMapping
+  public ResponseDTO findAll(@RequestBody OrderRequestDTO orderRequestDTO) {
+    return OrderService.findAll(orderRequestDTO);
+  }
+
+  @PostMapping("/{orderId:[0-9]+}")
+  public ResponseDTO findOne(@PathVariable Integer orderId) {
+    return OrderService.findOne(orderId);
+  }
+
+  @PutMapping
+  public ResponseDTO add(@RequestBody OrderAddDTO orderAddDTO) {
+    return OrderService.add(orderAddDTO);
+  }
+
+  @GetMapping
+  public ResponseDTO findAllOrders() {
+    return OrderService.findAllOrders();
+  }
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/OrderControllerDocs.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/OrderControllerDocs.java
@@ -1,0 +1,64 @@
+package cloud.weareithero.api.order;
+
+import cloud.weareithero.api.order.dto.OrderRequestDTO;
+import cloud.weareithero.api.order.dto.OrderAddDTO;
+import cloud.weareithero.docs.ApiCommonErrors;
+import cloud.weareithero.docs.ApiCommonSuccess;
+import cloud.weareithero.dto.ResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Order 관리", description = "Order 목록 조회 · Order 생성 · Order 상세 조회 API")
+public interface OrderControllerDocs {
+
+  @Operation(summary = "주문 내역 조회", description = "Order API")
+  @ApiCommonSuccess
+  @ApiCommonErrors
+  public ResponseDTO findAll(@RequestBody(
+    content = @Content(
+      schema = @Schema(implementation = OrderRequestDTO.class),
+      examples = {
+        @ExampleObject(
+            name = "1. 전체 검색 예시",
+            value = OrderResponseExamples.SUCCESS1_DEFAULT,
+            description = "전체 기간 동안의 주문 내역을 조회할 때 사용합니다."
+        ),
+        @ExampleObject(
+            name = "2. 주문 ID 단건 검색 예시",
+            value = OrderResponseExamples.SUCCESS2_DEFAULT,
+            description = "날짜 상관없이 특정 주문 번호로만 검색할 때 사용합니다."
+        ),
+        @ExampleObject(
+            name = "3. 날짜 범위 검색 예시",
+            value = OrderResponseExamples.SUCCESS3_DEFAULT,
+            description = "특정 기간 동안의 주문 내역을 조회할 때 사용합니다."
+        ),
+        @ExampleObject(
+            name = "4. 날짜 범위 및 주문 ID 검색 예시",
+            value = OrderResponseExamples.SUCCESS4_DEFAULT,
+            description = "특정 기간 동안의 해당 주문 Id 내역을 조회할 때 사용합니다."
+        ),
+      }
+    )) 
+    OrderRequestDTO orderRequestDTO);
+  
+  @Operation(summary = "주문 상세 조회", description = "Order API")
+  @ApiCommonSuccess
+  @ApiCommonErrors
+  public ResponseDTO findOne(Integer orderId);
+  
+  @Operation(summary = "주문 생성", description = "Order API")
+  @ApiCommonSuccess
+  @ApiCommonErrors
+  public ResponseDTO add(OrderAddDTO orderAddDTO);
+
+  @Operation(summary = "사전출고 통지(Outbound) 정보 조회", description = "Order API")
+  @ApiCommonSuccess
+  @ApiCommonErrors
+  public ResponseDTO findAllOutbound();
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/OrderControllerDocs.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/OrderControllerDocs.java
@@ -1,7 +1,7 @@
 package cloud.weareithero.api.order;
 
-import cloud.weareithero.api.order.dto.OrderRequestDTO;
 import cloud.weareithero.api.order.dto.OrderAddDTO;
+import cloud.weareithero.api.order.dto.OrderRequestDTO;
 import cloud.weareithero.docs.ApiCommonErrors;
 import cloud.weareithero.docs.ApiCommonSuccess;
 import cloud.weareithero.dto.ResponseDTO;
@@ -59,6 +59,6 @@ public interface OrderControllerDocs {
   @Operation(summary = "사전출고 통지(Outbound) 정보 조회", description = "Order API")
   @ApiCommonSuccess
   @ApiCommonErrors
-  public ResponseDTO findAllOutbound();
+  public ResponseDTO findAllOrders();
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/order/OrderResponseExamples.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/OrderResponseExamples.java
@@ -1,0 +1,42 @@
+package cloud.weareithero.api.order;
+
+public interface OrderResponseExamples {
+  
+  final String SUCCESS1_DEFAULT = """
+    {
+      "asnId": 0,
+      "orderStart": "",
+      "orderEnd": "",
+      "page": 1,
+      "size": 20
+    }
+    """;
+  final String SUCCESS2_DEFAULT = """
+    {
+      "asnId": 1,
+      "orderStart": "",
+      "orderEnd": "",
+      "page": 1,
+      "size": 20
+    }
+    """;
+  final String SUCCESS3_DEFAULT = """
+    {
+      "asnId": 0,
+      "orderStart": "2026-05-20",
+      "orderEnd": "2026-06-25",
+      "page": 1,
+      "size": 20
+    }
+    """;
+  final String SUCCESS4_DEFAULT = """
+    {
+      "asnId": 1,
+      "orderStart": "2026-05-20",
+      "orderEnd": "2026-06-25",
+      "page": 1,
+      "size": 20
+    }
+    """;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dao/OrderDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dao/OrderDao.java
@@ -1,0 +1,30 @@
+package cloud.weareithero.api.order.dao;
+
+import java.util.List;
+
+import cloud.weareithero.api.order.dto.OrderCustomerDTO;
+import cloud.weareithero.api.order.dto.OrderDTO;
+import cloud.weareithero.api.order.dto.OrderProductDTO;
+import cloud.weareithero.api.order.dto.OrderDetailProductDTO;
+import cloud.weareithero.api.order.dto.OrderRequestDTO;
+import cloud.weareithero.api.order.dto.OrderSummaryDTO;
+
+public interface OrderDao {
+
+  public OrderSummaryDTO findSummary(OrderRequestDTO orderRequestDTO);
+
+  public List<OrderDTO> findAll(OrderRequestDTO orderRequestDTO);
+
+  public OrderDTO findByOrderId(int orderId);
+
+  public List<OrderDetailProductDTO> findOne(int orderId);
+
+  public int add(OrderDTO orderDTO);
+
+  public int addOrderProduct(OrderDetailProductDTO orderDetailProductDTO);
+
+  public List<OrderCustomerDTO> findByCustomer();
+
+  public List<OrderProductDTO> findByProduct();
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dao/OrderDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dao/OrderDaoImp.java
@@ -1,0 +1,65 @@
+package cloud.weareithero.api.order.dao;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import cloud.weareithero.api.order.dao.OrderDao;
+import cloud.weareithero.api.order.dao.OrderMapper;
+import cloud.weareithero.api.order.dto.OrderDTO;
+import cloud.weareithero.api.order.dto.OrderProductDTO;
+import cloud.weareithero.api.order.dto.OrderDetailProductDTO;
+import cloud.weareithero.api.order.dto.OrderRequestDTO;
+import cloud.weareithero.api.order.dto.OrderSummaryDTO;
+import cloud.weareithero.api.order.dto.OrderCustomerDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class OrderDaoImp implements OrderDao {
+
+  private final OrderMapper orderMapper;
+
+  @Override
+  public OrderSummaryDTO findSummary(OrderRequestDTO orderRequestDTO) {
+    return orderMapper.findSummary(orderRequestDTO);
+  }
+
+  @Override
+  public List<OrderDTO> findAll(OrderRequestDTO orderRequestDTO) {
+    return orderMapper.findAll(orderRequestDTO);
+  }
+
+  @Override
+  public OrderDTO findByOrderId(int orderId) {
+    return orderMapper.findByOrderId(orderId);
+  }
+
+  @Override
+  public List<OrderDetailProductDTO> findOne(int orderId) {
+    return orderMapper.findOne(orderId);
+  }
+
+  @Override
+  public int add(OrderDTO orderDTO) {
+    return orderMapper.add(orderDTO);
+  }
+
+  @Override
+  public int addOrderProduct(OrderDetailProductDTO orderDetailProductDTO) {
+    return orderMapper.addOrderProduct(orderDetailProductDTO);
+  }
+
+  @Override
+  public List<OrderCustomerDTO> findByCustomer() {
+    return orderMapper.findByCustomer();
+  }
+
+  @Override
+  public List<OrderProductDTO> findByProduct() {
+    return orderMapper.findByProduct();
+  }
+  
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dao/OrderMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dao/OrderMapper.java
@@ -1,0 +1,190 @@
+package cloud.weareithero.api.order.dao;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+
+import cloud.weareithero.api.order.dto.OrderCustomerDTO;
+import cloud.weareithero.api.order.dto.OrderDTO;
+import cloud.weareithero.api.order.dto.OrderDetailProductDTO;
+import cloud.weareithero.api.order.dto.OrderProductDTO;
+import cloud.weareithero.api.order.dto.OrderRequestDTO;
+import cloud.weareithero.api.order.dto.OrderSummaryDTO;
+
+@Mapper
+public interface OrderMapper {
+
+  /**
+   * 1. Order 화면 상단 통계 블록 계산
+   * OrderSummaryDTO의 필드명(total, newOrder, inProgress, completed)에 완벽 바인딩
+   * 공통코드 기준: 7(출고대기->신규), 8(출고처리중->진행중), 9(출고완료->완료)
+   */
+  @Select("<script>" +
+      """
+          SELECT
+            COUNT(*) AS `total`,
+            SUM(CASE WHEN `opl`.`state_code` = 7 THEN 1 ELSE 0 END) AS `newOrder`,
+            SUM(CASE WHEN `opl`.`state_code` = 8 THEN 1 ELSE 0 END) AS `inProgress`,
+            SUM(CASE WHEN `opl`.`state_code` = 9 THEN 1 ELSE 0 END) AS `completed`
+          FROM `ORDER_PRODUCT_LIST` `opl`
+          JOIN `PARTNER_COMPANY_MASTER` `pcm`
+            ON `opl`.`partner_company_id` = `pcm`.`id`
+          """ +
+      "<where>" +
+      "<if test='orderStart != null and orderEnd != null'>" +
+      " AND `opl`.`order_date` BETWEEN #{orderStart} AND #{orderEnd} " +
+      "</if>" +
+      "<if test='orderNo != null and orderNo != \"\"'>" +
+      " AND `opl`.`id` LIKE CONCAT('%', #{orderNo}, '%') " +
+      "</if>" +
+      "<if test='customerName != null and customerName != \"\"'>" +
+      " AND `pcm`.`name` LIKE CONCAT('%', #{customerName}, '%') " +
+      "</if>" +
+      "</where>" +
+      "</script>")
+  public OrderSummaryDTO findSummary(OrderRequestDTO orderRequestDTO);
+
+  /**
+   * 2. Order 메인 그리드 목록 조회
+   * 화면 컬럼: 주문번호, 고객사명, 제품명, 수량, 금액, 주문일, 마감일 매핑
+   * PageRequestDTO의 페이징(offset, size) 연동
+   */
+  @Select("<script>" +
+      """
+          SELECT
+            `opl`.`id` AS `orderId`,
+            `opl`.`partner_company_id` AS `partnerId`,
+            `pcm`.`name` AS `partnerName`,
+            (SELECT `opm`.`name`
+             FROM `ORDER_PRODUCT` `op`
+             JOIN `OUTBOUND_PRODUCT_MASTER` `opm` ON `op`.`outbound_product_id` = `opm`.`id`
+             WHERE `op`.`order_product_list_id` = `opl`.`id` LIMIT 1) AS `orderProductName`,
+            (SELECT SUM(`op`.`quantity`)
+             FROM `ORDER_PRODUCT` `op`
+             WHERE `op`.`order_product_list_id` = `opl`.`id`) AS `itemCount`,
+            (SELECT SUM(CAST(`op`.`total_price` AS UNSIGNED))
+             FROM `ORDER_PRODUCT` `op`
+             WHERE `op`.`order_product_list_id` = `opl`.`id`) AS `price`,
+            `opl`.`order_date` AS `orderDate`,
+            `opl`.`deadline` AS `deadline`,
+            `cc`.`name` AS `stateCode`
+          FROM `ORDER_PRODUCT_LIST` `opl`
+          JOIN `PARTNER_COMPANY_MASTER` `pcm` ON `opl`.`partner_company_id` = `pcm`.`id`
+          LEFT JOIN `COMMON_CODE` `cc` ON `opl`.`state_code` = `cc`.`id`
+          """ +
+      "<where>" +
+      "<if test='orderStart != null and orderEnd != null'>" +
+      " AND `opl`.`order_date` BETWEEN #{orderStart} AND #{orderEnd} " +
+      "</if>" +
+      "<if test='orderNo != null and orderNo != \"\"'>" +
+      " AND `opl`.`id` LIKE CONCAT('%', #{orderNo}, '%') " +
+      "</if>" +
+      "<if test='customerName != null and customerName != \"\"'>" +
+      " AND `pcm`.`name` LIKE CONCAT('%', #{customerName}, '%') " +
+      "</if>" +
+      "</where>" +
+      "ORDER BY `opl`.`id` DESC LIMIT #{offset}, #{size}" +
+      "</script>")
+  public List<OrderDTO> findAll(OrderRequestDTO orderRequestDTO);
+
+  /**
+   * 3. 특정 주문 마스터 단건 조회 (상세 팝업 Master 정보용)
+   */
+  @Select("""
+      SELECT
+        `opl`.`id` AS `orderId`,
+        `opl`.`partner_company_id` AS `partnerId`,
+        `pcm`.`name` AS `partnerName`,
+        `opl`.`order_date` AS `orderDate`,
+        `opl`.`deadline` AS `deadline`,
+        `cc`.`name` AS `stateCode`
+      FROM `ORDER_PRODUCT_LIST` `opl`
+      JOIN `PARTNER_COMPANY_MASTER` `pcm` ON `opl`.`partner_company_id` = `pcm`.`id`
+      LEFT JOIN `COMMON_CODE` `cc` ON `opl`.`state_code` = `cc`.`id`
+      WHERE `opl`.`id` = #{orderId}
+      """)
+  public OrderDTO findByOrderId(int orderId);
+
+  /**
+   * 4. 상세 팝업 내부의 완제품 목록 리스트 조회
+   * 화면 컬럼: 제품명(itemName), 수량(setCount), 금액(price) 매핑
+   */
+  @Select("""
+      SELECT
+        `op`.`id` AS `no`,
+        `op`.`order_product_list_id` AS `orderId`,
+        `op`.`outbound_product_id` AS `itemNo`,
+        `opm`.`name` AS `itemName`,
+        `op`.`quantity` AS `setCount`,
+        `op`.`total_price` AS `price`
+      FROM `ORDER_PRODUCT` `op`
+      JOIN `OUTBOUND_PRODUCT_MASTER` `opm`
+        ON `op`.`outbound_product_id` = `opm`.`id`
+      WHERE `op`.`order_product_list_id` = #{orderId}
+      """)
+  public List<OrderDetailProductDTO> findOne(int orderId);
+
+  /**
+   * 5. 주문서 마스터 신규 생성
+   * DB 설계에 맞게 신규 등록 시 기본 상태코드는 '출고대기(7)'로 기본 할정
+   * useGeneratedKeys를 통해 생성된 AI 자동증가 ID를 orderId 필드에 자동으로 채워줌
+   */
+  @Insert("""
+      INSERT INTO `ORDER_PRODUCT_LIST` (
+        `partner_company_id`,
+        `order_date`,
+        `deadline`
+      ) VALUES (
+        #{partnerId},
+        #{orderDate},
+        #{deadline}
+      )
+      """)
+  @Options(useGeneratedKeys = true, keyProperty = "orderId", keyColumn = "id")
+  public int add(OrderDTO orderDTO);
+
+  /**
+   * 6. 주문 품목 상세 데이터(ORDER_PRODUCT) 저장
+   */
+  @Insert("""
+      INSERT INTO `ORDER_PRODUCT` (
+        `order_product_list_id`, -- DB 실제 컬럼명
+        `outbound_product_id`,   -- DB 실제 컬럼명
+        `quantity`,              -- DB 실제 컬럼명
+        `total_price`            -- DB 실제 컬럼명
+      ) VALUES (
+        #{orderId},              -- DTO의 orderId 변수값 바인딩
+        #{itemNo},               -- DTO의 itemNo 변수값 바인딩
+        #{setCount},             -- DTO의 setCount 변수값 바인딩
+        #{price}                 -- DTO의 price 변수값 바인딩
+      )
+      """)
+  public int addOrderProduct(OrderDetailProductDTO orderDetailProductDTO);
+
+  /**
+   * 7. 주문 등록 모달 및 검색 팝업용 고객사 리스트 조회 (customer_yn_code가 1인 협력사)
+   */
+  @Select("""
+      SELECT
+        `id`,
+        `name`
+      FROM `PARTNER_COMPANY_MASTER`
+      WHERE `customer_yn_code` = 1
+      """)
+  public List<OrderCustomerDTO> findByCustomer();
+
+  /**
+   * 8. 주문 등록 시 모달 그리드에 뿌려줄 출고 완제품 리스트 조회
+   */
+  @Select("""
+      SELECT
+        `id`,
+        `name`
+      FROM `OUTBOUND_PRODUCT_MASTER`
+      """)
+  public List<OrderProductDTO> findByProduct();
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderAddDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderAddDTO.java
@@ -1,0 +1,34 @@
+package cloud.weareithero.api.order.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter @Getter @ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "Order 등록 DTO")
+public class OrderAddDTO {
+
+  @Positive(message = "고객사 ID를 입력하세요.")
+  private int customerCompanyId;
+
+  @NotBlank(message = "주문 일자를 입력하세요.")
+  private String orderDate;
+
+  @NotBlank(message = "주문 마감 일자를 입력하세요.")
+  private String deadline;
+
+  @NotBlank(message = "출고 마감 일자를 입력하세요.")
+  private String eta;
+  
+  private List<OrderDetailProductDTO> items;
+  
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderCustomerDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderCustomerDTO.java
@@ -1,0 +1,15 @@
+package cloud.weareithero.api.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderCustomerDTO {
+  
+  private int id;
+  private String name;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderDTO.java
@@ -1,0 +1,27 @@
+package cloud.weareithero.api.order.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderDTO {
+                
+  private int orderId;            //: "PO-20260602-X01",          // 주문 번호
+  private int partnerId;          //: "1",                        // 공급사 번호, 발주처(고객사)
+  private String partnerName;     //: "(주)한성자재마트",           // 공급사명, 발주처(고객사)
+  private String orderProductName;//: "2023 현대 쏘나타 시트레일",   // 제품명
+  private int itemCount;          //: 1,200                       // 수량(세트)
+  private Long price;              //: 15,000,000                  // 가격(원)}
+  private LocalDate orderDate;     //: "2026-06-01"                // 주문 일시;
+  private LocalDate deadline;       //: "2026-06-30"               // 납기 일자  
+  private LocalDate eta;            //: "2026-06-30"               // 출고 마감 일자  
+  private String stateCode;         //: "신규"                     // 주문 상태 코드 (예: ORDER_RECEIVED, IN_PRODUCTION, SHIPPED, DELIVERED 등)
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderDetailProductDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderDetailProductDTO.java
@@ -1,0 +1,22 @@
+package cloud.weareithero.api.order.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "Order 상세 정보 DTO")
+public class OrderDetailProductDTO {
+  
+  private int no;
+  private int orderId;
+  private int itemNo; // 제품 PK: ORDER_PRODUCT_LIST의 PK (id)
+  private String itemName;
+  private int setCount;
+  private long price;
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderProductDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderProductDTO.java
@@ -1,0 +1,15 @@
+package cloud.weareithero.api.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderProductDTO {
+
+  private int id;
+  private String name;
+  
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderRequestDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderRequestDTO.java
@@ -1,0 +1,30 @@
+package cloud.weareithero.api.order.dto;
+
+import java.time.LocalDate;
+
+import cloud.weareithero.dto.PageRequestDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter @Getter @ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "주문 조회 요청 데이터")
+public class OrderRequestDTO extends PageRequestDTO {
+  
+  @Schema(description = "주문 시작일", example = "2026-06-01")
+  private LocalDate orderStart;
+  @Schema(description = "주문 종료일", example = "2026-06-30")
+  private LocalDate orderEnd;
+  @Schema(description = "주문 번호", defaultValue = "", example = "PO-20260602-X01")
+  private String orderNo;
+  @Schema(description = "고객사명", defaultValue = "", example = "(주)한성자재마트")
+  private String customerName;
+  @Schema(description = "진행 상태", defaultValue = "", example = "처리중")
+  private String status;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderSummaryDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderSummaryDTO.java
@@ -1,0 +1,17 @@
+package cloud.weareithero.api.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderSummaryDTO {
+  
+  private int total;
+  private int newOrder;
+  private int inProgress;
+  private int completed;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/service/OrderService.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/service/OrderService.java
@@ -1,0 +1,14 @@
+package cloud.weareithero.api.order.service;
+
+import cloud.weareithero.api.order.dto.OrderAddDTO;
+import cloud.weareithero.api.order.dto.OrderRequestDTO;
+import cloud.weareithero.dto.ResponseDTO;
+
+public interface OrderService {
+  
+  public ResponseDTO findAll(OrderRequestDTO orderRequestDTO);
+  public ResponseDTO findOne(int orderId);
+  public ResponseDTO add(OrderAddDTO orderAddDTO);
+  public ResponseDTO findAllOrders();
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/order/service/OrderServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/service/OrderServiceImp.java
@@ -1,0 +1,165 @@
+package cloud.weareithero.api.order.service;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import cloud.weareithero.api.order.dao.OrderDao;
+import cloud.weareithero.api.order.dto.OrderAddDTO;
+import cloud.weareithero.api.order.dto.OrderDTO;
+import cloud.weareithero.api.order.dto.OrderProductDTO;
+import cloud.weareithero.api.order.dto.OrderDetailProductDTO;
+import cloud.weareithero.api.order.dto.OrderRequestDTO;
+import cloud.weareithero.api.order.dto.OrderSummaryDTO;
+import cloud.weareithero.api.order.dto.OrderCustomerDTO;
+import cloud.weareithero.api.order.service.OrderService;
+import cloud.weareithero.dto.PaginationDTO;
+import cloud.weareithero.dto.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImp implements OrderService {
+
+  private final OrderDao orderDao;
+
+  @Override
+  public ResponseDTO findAll(OrderRequestDTO orderRequestDTO) {
+    boolean isSuccess = false;
+    String message = null;
+    Map<String, Object> request = new HashMap<>();
+    try {
+      OrderSummaryDTO summary = orderDao.findSummary(orderRequestDTO);
+      List<OrderDTO> orderList = orderDao.findAll(orderRequestDTO);
+      PaginationDTO pagination = PaginationDTO.builder()
+          .page(orderRequestDTO.getPage())
+          .totalCount(summary.getTotal())
+          .totalPages((int) Math.ceil((double) summary.getTotal() / orderRequestDTO.getSize()))
+          .build();
+      request.put("summary", summary);
+      request.put("list", orderList);
+      request.put("pagination", pagination);
+      isSuccess = true;
+      message = "Order 조회가 완료되었습니다.";
+    } catch (Exception e) {
+      log.info("OrderServiceImp findAll error : {}", e.getMessage());
+      message = "Order 조회에 실패했습니다.";
+    }
+    return ResponseDTO.builder()
+        .status(isSuccess)
+        .data(request)
+        .message(message)
+        .build();
+  }
+
+  @Override
+  public ResponseDTO findOne(int orderId) {
+    boolean isSuccess = false;
+    String message = null;
+    Map<String, Object> request = new HashMap<>();
+    try {
+      OrderDTO order = orderDao.findByOrderId(orderId);
+      List<OrderDetailProductDTO> orderProducts = orderDao.findOne(orderId);
+      request.put("order", order);
+      request.put("items", orderProducts);
+      isSuccess = true;
+      message = "Order 상세 정보 조회가 완료되었습니다.";
+    } catch (Exception e) {
+      log.info("OrderServiceImp findOne error : {}", e.getMessage());
+      message = "Order 상세 정보 조회가 실패했습니다.";
+    }
+    return ResponseDTO.builder()
+        .status(isSuccess)
+        .data(request)
+        .message(message)
+        .build();
+  }
+
+  @Override
+  public ResponseDTO add(OrderAddDTO orderAddDTO) {
+    boolean isSuccess = false;
+    String message = null;
+    Map<String, Object> request = new HashMap<>();
+    try {
+      int itemCount = orderAddDTO.getItems() == null ? 0 : orderAddDTO.getItems().size();
+
+      // 🚨 대시(-) 포맷을 명확하게 인식할 수 있도록 안전한 포맷터 정의
+      java.time.format.DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+      OrderDTO orderDTO = OrderDTO.builder()
+          .partnerId(orderAddDTO.getCustomerCompanyId())
+          .itemCount(itemCount)
+          // ⭕ 단순 parse 대신 포맷터를 지정하여 문자열을 안전하게 LocalDate로 변환합니다.
+          .orderDate(LocalDate.parse(orderAddDTO.getOrderDate(), formatter))
+          .deadline(LocalDate.parse(orderAddDTO.getDeadline(), formatter))
+          .eta(LocalDate.parse(orderAddDTO.getEta(), formatter))
+          .build();
+
+      orderDao.add(orderDTO);
+
+      if (orderDTO.getOrderId() > 0) { // 생성된 PK는 인자로 보낸 orderDTO에 채워져 있습니다.
+        isSuccess = true;
+        message = "Order 등록이 완료되었습니다.";
+        if (itemCount > 0) {
+          int size = 0;
+          for (OrderDetailProductDTO item : orderAddDTO.getItems()) {
+            // ⭕ OrderDetailProductDTO.builder()로 정상 변경
+            OrderDetailProductDTO orderDetailProductDTO = OrderDetailProductDTO.builder()
+                .orderId(orderDTO.getOrderId())
+                .itemNo(item.getItemNo()) // 💡 Swagger로 보낸 itemNo(1, 2)가 여기 정상 매핑되도록 추가
+                .itemName(item.getItemName())
+                .setCount(item.getSetCount())
+                .price(item.getPrice())
+                .build();
+
+            // Mapper로 수정된 DTO 객체를 안전하게 전달
+            size += orderDao.addOrderProduct(orderDetailProductDTO);
+          }
+
+          if (size != itemCount) {
+            isSuccess = false;
+            message = "Order 등록이 일부 실패했습니다.";
+          }
+        }
+      }
+
+    } catch (Exception e) {
+      log.info("OrderServiceImp add error : {}", e.getMessage());
+      message = "Order 등록이 실패했습니다.";
+    }
+    return ResponseDTO.builder()
+        .status(isSuccess)
+        .data(request)
+        .message(message)
+        .build();
+  }
+
+  @Override
+  public ResponseDTO findAllOrders() {
+    boolean isSuccess = false;
+    String message = null;
+    Map<String, Object> request = new HashMap<>();
+    try {
+      List<OrderCustomerDTO> customers = orderDao.findByCustomer();
+      List<OrderProductDTO> products = orderDao.findByProduct();
+      request.put("customers", customers);
+      request.put("products", products);
+      isSuccess = true;
+      message = "주문(Order) 정보 조회가 완료되었습니다.";
+    } catch (Exception e) {
+      log.info("OrderServiceImp findAllOrders error : {}", e.getMessage());
+      message = "주문(Order) 정보 조회가 실패했습니다.";
+    }
+    return ResponseDTO.builder()
+        .status(isSuccess)
+        .data(request)
+        .message(message)
+        .build();
+  }
+
+}


### PR DESCRIPTION
## 📝 개요
- **이슈 번호**: # 20
- **작업 유형**: `Fix & Refactor` (주문 관리 기능 백엔드 안정화)
- **한 줄 요약**: 주문 생성(POST) 시 발생하던 서버 런타임 예외 및 DB 매핑 에러를 해결하고, 대시보드 메인 그리드 조회 기능(POST /order) 검증을 완료했습니다.

---

## 🛠️ 주요 변경 사항

### 1. Database Schema 보완 (MariaDB)
- `ORDER_PRODUCT_LIST` (주문 마스터) 테이블에 누락되어 있던 상태 관리용 컬럼을 추가하여 비즈니스 데이터 무결성을 확보했습니다.
  ```sql
  ALTER TABLE `ORDER_PRODUCT_LIST` 
  ADD COLUMN `state_code` INT NOT NULL DEFAULT 7 COMMENT '출고상태코드(7:출고대기)';