### PR TITLE
outbound/outhistory 화면추가  (#28)

### DIFF
--- a/frontend/src/components/Layout/Sidebar.jsx
+++ b/frontend/src/components/Layout/Sidebar.jsx
@@ -13,8 +13,8 @@ const Sidebar = () => {
           <h4 className="released_icon">출고</h4>
           <li><a href="./order.html">주문</a></li>
           <li><a href="./packing.html">패킹</a></li>
-          <li><a href="./outbound.html">출고/송장</a></li>
-          <li><a href="./outhistory.html">출고이력</a></li>
+          <li><a onClick={()=>navigate("/home/outbound")}>출고/송장</a></li>
+          <li><a onClick={()=>navigate("/home/outhistory")}>출고이력</a></li>
       </ul>
       <ul>
           <h4 className="carbon_icon">탄소배출량</h4>

--- a/frontend/src/homes/inbound/Inbound.jsx
+++ b/frontend/src/homes/inbound/Inbound.jsx
@@ -95,7 +95,7 @@ const Inbound = () => {
     const [size, setSize] = useState(20);
     const [detailData, setDetailData] = useState(null);
 
-    const openInboundDetailModal = (id) => {
+    const openDetailModal = (id) => {
         POST(`/inbound/${id}`).then(res => {
             if (res.status === true) {
                 setDetailData(res.data);
@@ -192,7 +192,7 @@ const Inbound = () => {
                                 list?.map((v, i) =>
                                     <tr key={i}>
                                         <td className="text-center">{v.ata}</td>
-                                        <td className="font-bold text-link" onClick={() => openInboundDetailModal(v.asnId)}>{v.asnId}</td>
+                                        <td className="font-bold text-link" onClick={() => openDetailModal(v.asnId)}>{v.asnId}</td>
                                         <td>{v.partnerName}</td>
                                         <td className="text-center">{v.warehouseName}</td>
                                     </tr>

--- a/frontend/src/homes/main/index.jsx
+++ b/frontend/src/homes/main/index.jsx
@@ -1,10 +1,12 @@
 import { Routes, Route } from 'react-router';
+import '@styles/common.css';
 import Header from '@components/Layout/Header.jsx';
 import Sidebar from '@components/Layout/Sidebar.jsx';
 import Main from '@homes/Main/Main.jsx';
 import Asn from '@homes/inbound/Asn.jsx';
 import Inbound from '@homes/inbound/Inbound.jsx';
-import '@styles/common.css';
+import Outbound from '@homes/outbound/Outbound.jsx';
+import OutHistory from '@homes/outbound/OutHistory.jsx';
 import Anomaly from '@homes/carbonEmission/Anomaly.jsx';
 import CarbonDashboard from '@homes/carbonEmission/CarbonDashboard.jsx';
 
@@ -19,6 +21,8 @@ const Home = () => {
               <Route path='/' element={<Main />}/>
               <Route path='/asn' element={<Asn />}/>
               <Route path='/inbound' element={<Inbound />}/>
+              <Route path='/outbound' element={<Outbound />}/>
+              <Route path='/outhistory' element={<OutHistory />}/>
               <Route path='/anomaly' element={<Anomaly />}/>
               <Route path='/carbonemission' element={<CarbonDashboard />}/>
             </Routes>

--- a/frontend/src/homes/outbound/OutHistory.jsx
+++ b/frontend/src/homes/outbound/OutHistory.jsx
@@ -1,0 +1,155 @@
+import '@styles/outhistory.css';
+
+
+const OutHistory = () => {
+
+    
+    const openDetailModal = (id) => {
+
+    }
+
+    return (
+        <>
+            <div className="page-header-flex">
+                <h2 className="page-title">출고이력</h2>
+            </div>
+
+            <div className="order-summary-grid">
+
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">출고 확정</span>
+                        <span className="summary-value text-green">34<small>건</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge bg-green-light text-green">당월</span>
+                    </div>
+                </div>
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">기한 달성률</span>
+                        <span className="summary-value text-blue">5<small>%</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge bg-blue-light text-blue">당월</span>
+                    </div>
+                </div>
+
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">기한 임박 발생률</span>
+                        <span className="summary-value text-orange">5<small>%</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge bg-orange-light text-orange">당월</span>
+                    </div>
+                </div>
+
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">기한 초과 발생률</span>
+                        <span className="summary-value text-red">3<small>%</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge bg-red-light text-red">당월</span>
+                    </div>
+                </div>
+
+            </div>
+
+            <div className="filter-wrapper-card">
+                <form className="search-filter-grid">
+                    <div className="filter-group group-date-range">
+                        <label>출고 기간</label>
+                        <div className="date-range-container">
+                            <input type="date" id="search_start_date" className="filter-control" />
+                            <span className="date-separator">~</span>
+                            <input type="date" id="search_end_date" className="filter-control" />
+                        </div>
+                    </div>
+                    <div className="filter-group">
+                        <label>매니페스트 번호 검색</label>
+                        <div className="date-range-container">
+                            <input type="text" id="search_order_number" className="filter-control" />
+                        </div>
+                    </div>
+                    <div></div>
+                    <div className="filter-btn-group">
+                        <button type="reset" className="btn-filter-reset">초기화</button>
+                        <button type="submit" className="btn-filter-search">조회하기</button>
+                    </div>
+                </form>
+            </div>
+
+            <div className="content-card">
+                <div className="table-responsive">
+                    <div className="inhistory-btn-group">
+                        <button type="button" className="btn-filter-reset">엑셀 다운로드</button>
+                        <button type="submit" className="btn-filter-search">새로고침</button>
+                    </div>
+                    <table className="history-data-table">
+                        <thead>
+                            <tr>
+                                <th>출고일자</th>
+                                <th>매니페스트 번호</th>
+                                <th>운송사</th>
+                                <th>출고 제품 수량(세트)</th>
+                                <th>요청 수량</th>
+                            </tr>
+                        </thead>
+                        <tbody id="historyTableBody">
+                            <tr>
+                                <td className="text-center">2026-05-28</td>
+                                <td className="font-bold text-link" onClick={openDetailModal(1)}>
+                                    ASN-20260602-001</td>
+                                <td className="text-center">대한택배</td>
+                                <td>15</td>
+                                <td className="text-center">5,000</td>
+                            </tr>
+                            <tr>
+                                <td className="text-center">2026-05-26</td>
+                                <td className="font-bold text-link" onClick={openDetailModal(2)}>
+                                    ASN-20260602-002</td>
+                                <td className="text-center">대한택배</td>
+                                <td>15</td>
+                                <td className="text-center">2,500</td>
+                            </tr>
+                            <tr>
+                                <td className="text-center">2026-05-26</td>
+                                <td className="font-bold text-link" onClick={openDetailModal(3)}>
+                                    ASN-20260602-002</td>
+                                <td className="text-center">대한택배</td>
+                                <td>15</td>
+                                <td className="text-center">2,500</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div className="pagination-container">
+                    <div className="pagination-info">
+                        전체 <span>3</span>건
+                    </div>
+
+                    <div className="pagination-buttons">
+                        <button type="button" className="btn-page" title="처음 페이지" disabled>&lt;&lt;</button>
+                        <button type="button" className="btn-page" title="이전 블록" disabled>&lt;</button>
+
+                        <button type="button" className="btn-page-num active">1</button>
+                        <button type="button" className="btn-page-num">2</button>
+                        <button type="button" className="btn-page-num">3</button>
+                        <button type="button" className="btn-page-num">4</button>
+                        <button type="button" className="btn-page-num">5</button>
+
+                        <button type="button" className="btn-page" title="다음 블록">&gt;</button>
+                        <button type="button" className="btn-page" title="끝 페이지">&gt;&gt;</button>
+                    </div>
+                </div>
+
+            </div>
+
+        </>
+    )
+}
+
+export default OutHistory;

--- a/frontend/src/homes/outbound/Outbound.jsx
+++ b/frontend/src/homes/outbound/Outbound.jsx
@@ -1,0 +1,115 @@
+import '@styles/outbound.css';
+import { useState } from 'react';
+
+
+const Outbound = () => {
+
+    return (
+        <>
+            <div className="page-header-flex">
+                <h2 className="page-title">출고/송장</h2>
+                <div className="header-action-group">
+                    {/* <button className="btn-secondary-action">엑셀 내보내기</button>
+                    <button className="btn-main-action" onclick="openOrderModal()">+ 신규 주문 등록</button> */}
+                </div>
+            </div>
+
+            <div className="order-summary-grid">
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">출고 예정</span>
+                        <span className="summary-value">42<small>건</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge bg-all-light text-muted">당일</span>
+                    </div>
+                </div>
+
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">출고 확정</span>
+                        <span className="summary-value text-green">34<small>건</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge bg-green-light text-green">당일</span>
+                    </div>
+                </div>
+
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">기한 임박</span>
+                        <span className="summary-value text-orange">5<small>건</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge bg-orange-light text-orange">당일</span>
+                    </div>
+                </div>
+
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">기한 초과</span>
+                        <span className="summary-value text-red">3<small>건</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge bg-red-light text-red">당일</span>
+                    </div>
+                </div>
+
+                <div className="summary-card-item">
+                    <div className="card-info-left">
+                        <span className="summary-label">미배정</span>
+                        <span className="summary-value text-dark">3<small>건</small></span>
+                    </div>
+                    <div className="card-trend-right">
+                        <span className="status-badge table-badge badge-dark">당일</span>
+                    </div>
+                </div>
+
+            </div>
+
+            <div className="filter-wrapper-card">
+                <form className="search-filter-grid">
+                    <div className="filter-group group-date-range">
+                        <label>주문 기간</label>
+                        <div className="date-range-container">
+                            <input type="date" id="search_start_date" className="filter-control" />
+                            <span className="date-separator">~</span>
+                            <input type="date" id="search_end_date" className="filter-control" />
+                        </div>
+                    </div>
+                    <div className="filter-group">
+                        <label>주문번호 검색</label>
+                        <div className="date-range-container">
+                            <input type="text" id="search_order_number" className="filter-control" />
+                        </div>
+                    </div>
+
+                    <div className="filter-group">
+                        <label>고객사 검색</label>
+                        <div className="date-range-container">
+                            <input type="text" id="search_order_number" className="filter-control" />
+                        </div>
+                    </div>
+
+                    <div className="filter-group">
+                        <label htmlFor="search_status">진행 상태</label>
+                        <select id="search_status" className="filter-control">
+                            <option value="">전체 상태</option>
+                            <option value="approved">신규</option>
+                            <option value="pending">처리중</option>
+                            <option value="rejected">완료</option>
+                        </select>
+                    </div>
+
+                    <div className="filter-btn-group">
+                        <button type="reset" className="btn-filter-reset">초기화</button>
+                        <button type="submit" className="btn-filter-search">조회하기</button>
+                    </div>
+                </form>
+            </div>
+                    
+        </>
+    )
+}
+
+export default Outbound;

--- a/frontend/src/styles/outbound.css
+++ b/frontend/src/styles/outbound.css
@@ -1,0 +1,1080 @@
+/* ==========================================================================
+   주문 계약 및 접수 현황 컴포넌트 스타일시트 (수정본)
+   ========================================================================== */
+
+.header-action-group {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.btn-secondary-action {
+    background-color: #ffffff;
+    color: #4a5568;
+    border: 1px solid var(--border-color);
+    padding: 0.6rem 1.2rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-secondary-action:hover {
+    background-color: #f8fafc;
+}
+
+/* 1. [변경] 입고이력 구조(history-summary-grid)와 결합된 상단 주문 그리드 */
+.order-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.summary-card-item {
+    background-color: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.01);
+}
+
+/* 내부 데이터 텍스트 배벨 정렬 트랙 */
+.card-info-left {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.summary-value {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--text-dark);
+    line-height: 1.1;
+}
+
+.summary-value small {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-weight: 500;
+    margin-left: 0.15rem;
+}
+
+/* 우측 상태 고정 배지 가로 폭 맞춤 */
+.card-trend-right {
+    display: flex;
+    align-items: center;
+}
+
+.status-badge {
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+/* 입고이력 톤앤매너에 맞춘 배경 및 폰트 유틸리티 매핑 */
+.bg-all-light {
+    background-color: #f1f5f9;
+}
+
+.bg-orange-light {
+    background-color: #fffaf0;
+    border: 1px solid #feebc8;
+}
+
+.bg-green-light {
+    background-color: #f0fff4;
+    border: 1px solid #c6f6d5;
+}
+
+.bg-red-light {
+    background-color: #fff5f5;
+    border: 1px solid #fed7d7;
+}
+
+.bg-blue-light {
+    background-color: #f0f9ff;
+    border: 1px solid #bcdef1;
+}
+
+/* 2. 검색 조건 필터 서식 */
+
+
+
+
+/* 3. 테이블 및 범용 클래스 */
+.order-data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+}
+
+.order-data-table th {
+    background-color: #f8fafc;
+    color: var(--text-dark);
+    font-weight: 600;
+    padding: 0.75rem 1rem;
+    border-bottom: 2px solid var(--border-color);
+}
+
+.order-data-table td {
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.text-link {
+    color: var(--primary-green);
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.text-center {
+    text-align: center !important;
+}
+
+.text-right {
+    text-align: right !important;
+}
+
+.font-bold {
+    font-weight: 600;
+}
+
+.text-orange {
+    color: #dd6b20 !important;
+}
+
+.text-green {
+    color: var(--primary-green) !important;
+}
+
+.text-blue {
+    color: #3182ce !important;
+}
+
+.text-muted {
+    color: var(--text-muted) !important;
+}
+
+.text-red {
+    color: var(--accent-red) !important;
+}
+
+.table-badge {
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.table-badge.badge-dark {
+    background-color: #f1f1f1;
+    color: var(--text-muted);
+    border: 1px solid #d1d1d1;
+}
+
+.table-badge.badge-success {
+    background-color: #e6fffa;
+    color: #234e52;
+    border: 1px solid #b2f5ea;
+}
+
+.table-badge.badge-pending {
+    background-color: #fffaf0;
+    color: #7b341e;
+    border: 1px solid #feebc8;
+}
+
+.table-badge.badge-danger {
+    background-color: #fff5f5;
+    color: #742a2a;
+    border: 1px solid #fed7d7;
+}
+
+/* 미디어 쿼리 최적화 처리 */
+@media (max-width: 1300px) {
+    .order-summary-grid {
+        grid-template-columns: repeat(5, 1fr);
+    }
+
+    .search-filter-grid {
+        grid-template-columns: repeat(5, 1fr);
+    }
+
+    .filter-btn-group {
+        grid-column: span 2;
+        justify-content: flex-end;
+    }
+}
+
+@media (max-width: 640px) {
+    .order-summary-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .search-filter-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .filter-btn-group {
+        grid-column: span 1;
+    }
+}
+
+
+/* ==========================================================================
+   2. [수정 및 확장] 대시보드 내 검색 조건 필터 카드 레이아웃 정렬 서식
+   ========================================================================== */
+.filter-wrapper-card {
+    background-color: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+/* 4열 분할에서 기간 단위 확장형 3열 배분 구조로 최적화 */
+.search-filter-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr auto;
+    gap: 1.5rem;
+    align-items: flex-end;
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* 기간 범위 데이터 컨테이너 스타일 */
+.group-date-range {
+    width: 100%;
+}
+
+
+
+.date-separator {
+    color: var(--text-muted);
+    font-weight: 600;
+    padding: 0 0.2rem;
+}
+
+.filter-group label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.filter-control {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    font-size: 0.9rem;
+    color: var(--text-dark);
+    background-color: #ffffff;
+    height: 38px;
+    outline: none;
+}
+
+.filter-control:focus {
+    border-color: var(--primary-green);
+}
+
+.filter-btn-group {
+    display: flex;
+    gap: 0.5rem;
+    height: 38px;
+}
+
+.btn-filter-reset {
+    background-color: #edf2f7;
+    color: #4a5568;
+    border: none;
+    padding: 0 1.2rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+
+
+/* 태블릿/모바일 등 작은 화면에서의 반응형 브레이크포인트 자동 재배치 */
+@media (max-width: 1024px) {
+    .search-filter-grid {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+
+    .date-range-container {
+        flex-direction: row;
+    }
+
+    .filter-btn-group {
+        justify-content: flex-end;
+        margin-top: 0.5rem;
+    }
+}
+
+/* ==========================================================================
+   3. [신규 추가] 신규 주문 입력 모달 팝업 UI 서식
+   ========================================================================== */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+}
+
+.modal-overlay.active {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.modal-container {
+    background-color: #ffffff;
+    width: 680px;
+    max-width: 90%;
+    border-radius: 8px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    max-height: 85vh;
+    animation: modalSlideUp 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes modalSlideUp {
+    from {
+        transform: translateY(20px);
+        opacity: 0;
+    }
+
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+.modal-header {
+    padding: 1.2rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h3 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.modal-close-btn {
+    background: none;
+    border: none;
+    font-size: 1.75rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    line-height: 1;
+}
+
+.modal-close-btn:hover {
+    color: var(--accent-red);
+}
+
+.modal-body {
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+
+/* 폼 마스터 그리드 */
+.modal-form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.form-group label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.required {
+    color: var(--accent-red);
+    margin-left: 0.1rem;
+}
+
+/* 공통 입력 엘리먼트 서식 */
+.modal-input,
+.modal-select {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #cbd5e0;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    color: var(--text-dark);
+    height: 38px;
+    outline: none;
+    background-color: #ffffff;
+}
+
+.modal-input:focus,
+.modal-select:focus {
+    border-color: var(--primary-green);
+    box-shadow: 0 0 0 2px rgba(3, 169, 77, 0.15);
+}
+
+/* 섹션 타이틀 및 가변 제어 버튼 트랙 */
+.modal-section-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.5rem;
+}
+
+.modal-section-title h4 {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.btn-secondary-sm {
+    background-color: #ffffff;
+    color: var(--primary-green);
+    border: 1px solid var(--primary-green);
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-secondary-sm:hover {
+    background-color: rgba(3, 169, 77, 0.05);
+}
+
+/* 팝업 테이블 서식 */
+.modal-table-responsive {
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.modal-product-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.modal-product-table th {
+    background-color: #f8fafc;
+    color: #4a5568;
+    font-weight: 600;
+    font-size: 0.85rem;
+    padding: 0.6rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-product-table td {
+    padding: 0.5rem;
+    border-bottom: 1px solid var(--border-color);
+    vertical-align: middle;
+}
+
+.modal-product-table tr:last-child td {
+    border-bottom: none;
+}
+
+/* 정렬 헬퍼 클래스 */
+.text-right {
+    text-align: right;
+}
+
+.text-center {
+    text-align: center;
+}
+
+/* 행 삭제 x 버튼 */
+.btn-delete-row {
+    background: none;
+    border: none;
+    color: #a0aec0;
+    font-size: 1.4rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 0.5rem;
+}
+
+.btn-delete-row:hover {
+    color: var(--accent-red);
+}
+
+/* 모달 하단 버튼 액션 바 */
+.modal-footer {
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    background-color: #f8fafc;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+}
+
+.btn-pop-cancel {
+    background-color: #ffffff;
+    color: #4a5568;
+    border: 1px solid #cbd5e0;
+    padding: 0.55rem 1.2rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-pop-cancel:hover {
+    background-color: #edf2f7;
+}
+
+.btn-pop-submit {
+    background-color: var(--primary-green);
+    color: white;
+    border: none;
+    padding: 0.55rem 1.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-pop-submit:hover {
+    background-color: var(--primary-hover);
+}
+
+
+
+
+/* ==========================================================================
+   주문 상세 팝업 좌우 2분할 레이아웃 및 바코드 스타일 스타일시트
+   ========================================================================== */
+
+/* 좌우 분할 그리드 스케일 */
+.modal-split-layout {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 1.25rem;
+    border-top: 1px solid var(--border-color);
+    padding-top: 1rem;
+}
+
+.modal-split-left,
+.modal-split-right {
+    display: flex;
+    flex-direction: column;
+}
+
+/* 테이블 클릭 이펙트 스타일 */
+.clickable-table tbody tr:hover {
+    background-color: #f7fafc;
+}
+
+.clickable-table tbody tr.selected-row {
+    background-color: #e6fffa !important;
+    border-left: 3px solid var(--primary-green);
+}
+
+/* 우측 송장 카드 디자인 박스 */
+.invoice-preview-card {
+    background-color: #f8fafc;
+    border: 1px dashed #cbd5e0;
+    border-radius: 6px;
+    padding: 1.25rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 280px;
+}
+
+.empty-invoice-msg {
+    text-align: center;
+    color: #a0aec0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.invoice-box-inner {
+    width: 100%;
+    background: #ffffff;
+    border: 1px solid #cbd5e0;
+    border-radius: 4px;
+    padding: 1rem;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.03);
+}
+
+.invoice-header-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #2d3748;
+    text-align: center;
+    border-bottom: 2px dashed #e2e8f0;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.invoice-mini-table {
+    width: 100%;
+    margin-bottom: 1rem;
+    border-collapse: collapse;
+}
+
+.invoice-mini-table th {
+    background-color: #f1f5f9 !important;
+    color: #4a5568;
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.4rem 0.6rem;
+    width: 30%;
+    text-align: left !important;
+    border: 1px solid #e2e8f0;
+}
+
+.invoice-mini-table td {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.85rem;
+    color: #2d3748;
+    text-align: left !important;
+    border: 1px solid #e2e8f0;
+}
+
+/* CSS 바코드 모듈 그래픽 생성 컴포넌트 */
+.barcode-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: white;
+    padding: 0.75rem 0.5rem;
+    border: 1px solid #e2e8f0;
+    margin-top: 0.5rem;
+}
+
+.barcode-lines {
+    display: flex;
+    align-items: stretch;
+    height: 45px;
+    background: #000;
+}
+
+/* 바코드 선 두께 유틸리티 배열 */
+.barcode-lines span {
+    display: inline-block;
+    background: #fff;
+    height: 100%;
+}
+
+.barcode-lines .b-w-1 {
+    width: 1px;
+    background: #000;
+}
+
+.barcode-lines .b-w-2 {
+    width: 3px;
+    background: #000;
+}
+
+.barcode-lines .b-w-3 {
+    width: 2px;
+    background: #fff;
+}
+
+.barcode-lines .b-w-4 {
+    width: 4px;
+    background: #fff;
+}
+
+.barcode-text {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.75rem;
+    font-weight: bold;
+    letter-spacing: 2px;
+    margin-top: 0.25rem;
+    color: #1a202c;
+}
+
+.invoice-footer-action {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.75rem;
+    border-top: 1px solid #e2e8f0;
+    padding-top: 0.5rem;
+}
+
+
+/* ==========================================================================
+   추가 배송 설정 제어존 및 송장 생성 버튼 스타일
+   ========================================================================== */
+
+/* 배송 설정 컨테이너 컴포넌트 */
+.delivery-config-zone {
+    background-color: #f8fafc;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1rem;
+}
+
+.config-form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.config-form-row .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.config-form-row label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.select-styled {
+    height: 36px;
+    padding: 0 0.5rem;
+    font-size: 0.85rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: #ffffff;
+    color: var(--text-dark);
+}
+
+.select-styled:focus {
+    border-color: var(--primary-green);
+    outline: none;
+}
+
+/* 송장 생성 전용 대형 버튼 */
+.action-btn-wrap {
+    margin-top: 0.5rem;
+}
+
+.btn-generate-invoice {
+    width: 100%;
+    background-color: var(--primary-green);
+    color: #ffffff;
+    border: none;
+    padding: 0.75rem;
+    font-size: 0.95rem;
+    font-weight: 700;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.1s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    box-shadow: 0 2px 4px rgba(3, 169, 77, 0.15);
+}
+
+.btn-generate-invoice:hover {
+    background-color: var(--primary-hover);
+}
+
+.btn-generate-invoice:active {
+    transform: scale(0.99);
+}
+
+/* 우측 송장 카드 박스 내부 정렬 보정 */
+.invoice-preview-card {
+    min-height: 380px;
+    /* 늘어난 정보량에 대응하도록 최소 높이 확장 */
+}
+
+.view-toggle-container {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 0.5rem;
+}
+
+.btn-toggle-view {
+    background-color: #ffffff;
+    color: #4a5568;
+    border: 1px solid var(--border-color);
+    padding: 0.5rem 1.5rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-toggle-view:hover {
+    background-color: #f8fafc;
+}
+
+.btn-toggle-view.active {
+    background-color: var(--primary-green);
+    color: #ffffff;
+    border-color: var(--primary-green);
+}
+
+/* 테이블 뷰 숨김 제어 */
+.table-view-content {
+    display: none;
+}
+
+.table-view-content.active {
+    display: block;
+}
+
+.toggle-left,
+.toggle-right {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.view-toggle-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.btn-action-gray,
+.btn-action-blue,
+.btn-action-green {
+    border: none;
+    padding: 0.55rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    color: #fff;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.btn-action-gray {
+    background: #64748b;
+}
+
+.btn-action-blue {
+    background: #2563eb;
+}
+
+.btn-action-green {
+    background: #16a34a;
+}
+
+.invoice-split-container {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+    border-top: 1px solid var(--border-color);
+    margin-top: 0.5rem;
+}
+
+.invoice-left-pane {
+    display: table-cell;
+    width: 240px;
+    vertical-align: top;
+    border-right: 1px solid var(--border-color);
+    background-color: #f8fafc;
+    padding: 1rem 0.75rem;
+}
+
+.invoice-right-pane {
+    display: table-cell;
+    vertical-align: top;
+    padding: 1rem 1.5rem;
+    background-color: #ffffff;
+}
+
+/* 2. 좌측 박스 리스트 컴포넌트 */
+.box-list-title {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-dark);
+    margin-bottom: 0.75rem;
+    padding-left: 0.25rem;
+}
+
+.box-item-ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.box-item-li {
+    padding: 0.75rem 1rem;
+    background-color: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.15s ease-in-out;
+}
+
+.box-item-li:hover {
+    background-color: #edf2f7;
+    color: var(--text-dark);
+}
+
+.box-item-li.active {
+    background-color: var(--primary-green);
+    color: #ffffff;
+    border-color: var(--primary-green);
+    box-shadow: 0 2px 6px rgba(3, 169, 77, 0.2);
+}
+
+/* 3. 모달 크기 확장 조정 (2분할 대응 구조) */
+#invoice-modal .modal-content {
+    width: 820px !important;
+    max-width: 90%;
+    padding: 0 !important;
+    /* 샌드위치 패널 구조 레이아웃화 */
+}
+
+#invoice-modal .modal-header {
+    padding: 1.25rem 1.5rem 0.75rem 1.5rem;
+}
+
+#invoice-modal .modal-footer {
+    padding: 1rem 1.5rem 1.25rem 1.5rem;
+    border-top: 1px solid var(--border-color);
+    background-color: #f8fafc;
+}
+
+/* 4. 버튼 3종 세트 정형화 */
+.btn-invoice-print {
+    background-color: #3182ce;
+    color: #ffffff;
+    border: 1px solid #3182ce;
+    padding: 0.55rem 1.2rem;
+    font-size: 0.88rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-invoice-print:hover {
+    background-color: #2b6cb0;
+}
+
+.btn-invoice-print-all {
+    background-color: var(--primary-green);
+    color: #ffffff;
+    border: 1px solid var(--primary-green);
+    padding: 0.55rem 1.2rem;
+    font-size: 0.88rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-invoice-print-all:hover {
+    background-color: var(--primary-hover);
+}
+
+.btn-invoice-cancel {
+    background-color: #ffffff;
+    color: #4a5568;
+    border: 1px solid #cbd5e0;
+    padding: 0.55rem 1.2rem;
+    font-size: 0.88rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-invoice-cancel:hover {
+    background-color: #f7fafc;
+}
+
+.invoice-manager-layout{
+    display:flex;
+    gap:20px;
+    height:600px;
+}
+
+.invoice-box-list{
+    width:260px;
+    border:1px solid var(--border-color);
+    border-radius:6px;
+    overflow:hidden;
+    background:#fff;
+}
+
+.invoice-list-title{
+    padding:15px;
+    font-weight:700;
+    border-bottom:1px solid var(--border-color);
+    background:#f8fafc;
+}
+
+#invoiceBoxList{
+    list-style:none;
+    margin:0;
+    padding:0;
+    max-height:540px;
+    overflow-y:auto;
+}
+
+.invoice-list-item{
+    padding:12px 16px;
+    cursor:pointer;
+    border-bottom:1px solid #f1f5f9;
+    transition:.2s;
+}
+
+.invoice-list-item:hover{
+    background:#f8fafc;
+}
+
+.invoice-list-item.active{
+    background:#e6f7ee;
+    color:var(--primary-green);
+    font-weight:700;
+}
+
+.invoice-preview-panel{
+    flex:1;
+}

--- a/frontend/src/styles/outhistory.css
+++ b/frontend/src/styles/outhistory.css
@@ -1,0 +1,1238 @@
+/* ==========================================================================
+   자재 입고이력 공급망 전용 스타일시트 (inhistory.css)
+   ========================================================================== */
+
+/* 상단 액션 그룹 레이아웃 */
+.history-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.btn-action-green {
+    background-color: var(--primary-green);
+    color: white;
+    border: none;
+    padding: 0.5rem 1.1rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.btn-action-green:hover {
+    background-color: var(--primary-hover);
+}
+
+.btn-action-gray {
+    background-color: #ffffff;
+    color: #4a5568;
+    border: 1px solid #cbd5e0;
+    padding: 0.5rem 1.1rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-action-gray:hover {
+    background-color: #f7fafc;
+    border-color: #a0aec0;
+}
+
+/* 4분할 통계 데이터 현황판 그리드 */
+.history-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.25rem;
+    margin-bottom: 1.25rem;
+}
+
+.summary-card {
+    background-color: #ffffff;
+    border: 1px solid var(--border-color);
+    border-left: 4px solid #718096;
+    border-radius: 6px;
+    padding: 1.25rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.02);
+}
+
+/* 신규 공급망 인디케이터 컬러 매핑 */
+.summary-card.border-blue { border-left-color: #3182ce; }
+.summary-card.border-purple { border-left-color: #805ad5; }
+.summary-card.border-indigo { border-left-color: #4c51bf; }
+.summary-card.border-green { border-left-color: var(--primary-green); }
+
+
+.content-card {
+    background-color: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.02);
+    overflow-x: auto;
+    
+}
+
+
+.card-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.card-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+.card-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.card-value small {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-muted);
+}
+
+/* 신규 텍스트 컬러 유틸리티 */
+.text-purple { color: #805ad5 !important; }
+.text-indigo { color: #4c51bf !important; }
+.text-green { color: var(--primary-green) !important; }
+
+/* 입고이력 메인 데이터 테이블 */
+.history-data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+}
+
+.history-data-table th,
+.history-data-table td {
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    white-space: nowrap;
+}
+
+.history-data-table th {
+    background-color: #f8fafc;
+    color: var(--text-dark);
+    font-weight: 600;
+}
+
+.history-data-table tbody tr:hover td {
+    background-color: #f1f5f9;
+}
+
+.text-center { text-align: center !important; }
+.text-right { text-align: right !important; }
+.font-bold { font-weight: 600; }
+.text-link { color: var(--primary-green); cursor: pointer; text-decoration: underline;}
+
+/* 미디어 쿼리 반응형 처리 */
+@media (max-width: 1200px) {
+    .history-summary-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+@media (max-width: 640px) {
+    .history-summary-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+
+/* ==========================================================================
+   표 하단 페이지네이션 전용 레이아웃 확장 서식 
+   ========================================================================== */
+
+.pagination-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+    background-color: #ffffff;
+}
+
+/* 좌측 정보 텍스트 서식 */
+.pagination-info {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.pagination-info span {
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+/* 중앙 페이지네이션 버튼 트랙 */
+.pagination-buttons {
+    display: flex;
+    gap: 0.35rem;
+    align-items: center;
+}
+
+/* 우측 페이지 로우 셀렉터 박스 */
+.pagination-size-selector select {
+    padding: 0.4rem 1.8rem 0.4rem 0.75rem;
+    font-size: 0.85rem;
+    color: var(--text-dark);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: #ffffff;
+    cursor: pointer;
+    outline: none;
+    transition: border-color 0.15s ease;
+}
+
+.pagination-size-selector select:focus {
+    border-color: var(--primary-green);
+}
+
+
+/* ==========================================================================
+   [추가] ASN 상세 조회 모달 전용 테두리 및 링크 스타일 서식
+   ========================================================================== */
+.text-link {
+    color: var(--primary-green) !important;
+    text-decoration: underline !important;
+    cursor: pointer;
+    font-weight: 700;
+}
+
+.text-link:hover {
+    color: var(--primary-hover) !important;
+}
+
+/* 1. 모달 전체 오버레이 기본 숨김 처리 (★핵심 수정사항) */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: none; /* 기본 상태는 숨김 */
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+/* active 클래스가 붙으면 유연하게 화면 중앙 배치 노출 */
+.modal-overlay.active {
+    display: flex !important;
+}
+
+/* 2. 모달 컨테이너 윈도우 상자 디자인 */
+.modal-window {
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    animation: modalFadeIn 0.25s ease-out;
+    overflow: hidden;
+}
+
+@keyframes modalFadeIn {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* 3. 모달 헤더 구역 */
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    background-color: #ffffff;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-header h3 {
+    font-size: 1.1rem;
+    color: var(--text-dark);
+    font-weight: 700;
+    margin: 0;
+}
+
+.modal-close-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: #a0aec0;
+    cursor: pointer;
+}
+
+.modal-close-btn:hover {
+    color: var(--text-dark);
+}
+
+/* 4. 엑셀 시트 탭 스타일시트 매칭 */
+.sheet-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border-color);
+    background-color: #f8fafc;
+}
+
+.sheet-tab-btn {
+    padding: 0.6rem 1.2rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #4a5568;
+    background: none;
+    border: none;
+    border-right: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.sheet-tab-btn.active {
+    background-color: #ffffff;
+    color: var(--primary-green);
+    font-weight: 700;
+    border-bottom: 2px solid var(--primary-green);
+    margin-bottom: -1px;
+}
+
+/* 5. 엑셀 양식 테이블 팝업 전용 상세 테두리 라인업 */
+.excel-styled-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.excel-styled-table th {
+    font-weight: 600;
+    color: #4a5568;
+    background-color: #f1f5f9 !important;
+    border: 1px solid var(--border-color) !important;
+    text-align: center !important;
+    padding: 0.5rem;
+    font-size: 0.85rem;
+}
+
+.excel-styled-table td {
+    border: 1px solid var(--border-color) !important;
+    padding: 0.6rem;
+    font-size: 0.85rem;
+    vertical-align: middle;
+}
+
+
+/* ==========================================================================
+   주문 계약 및 접수 현황 컴포넌트 스타일시트 (수정본)
+   ========================================================================== */
+
+.header-action-group {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.btn-secondary-action {
+    background-color: #ffffff;
+    color: #4a5568;
+    border: 1px solid var(--border-color);
+    padding: 0.6rem 1.2rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-secondary-action:hover {
+    background-color: #f8fafc;
+}
+
+/* 1. [변경] 입고이력 구조(history-summary-grid)와 결합된 상단 주문 그리드 */
+.order-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.summary-card-item {
+    background-color: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.01);
+}
+
+/* 내부 데이터 텍스트 배벨 정렬 트랙 */
+.card-info-left {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.summary-value {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--text-dark);
+    line-height: 1.1;
+}
+
+.summary-value small {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-weight: 500;
+    margin-left: 0.15rem;
+}
+
+/* 우측 상태 고정 배지 가로 폭 맞춤 */
+.card-trend-right {
+    display: flex;
+    align-items: center;
+}
+
+.status-badge {
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+/* 입고이력 톤앤매너에 맞춘 배경 및 폰트 유틸리티 매핑 */
+.bg-all-light {
+    background-color: #f1f5f9;
+}
+
+.bg-orange-light {
+    background-color: #fffaf0;
+    border: 1px solid #feebc8;
+}
+
+.bg-green-light {
+    background-color: #f0fff4;
+    border: 1px solid #c6f6d5;
+}
+
+.bg-red-light {
+    background-color: #fff5f5;
+    border: 1px solid #fed7d7;
+}
+
+.bg-blue-light {
+    background-color: #f0f9ff;
+    border: 1px solid #bcdef1;
+}
+
+/* 2. 검색 조건 필터 서식 */
+
+
+
+
+/* 3. 테이블 및 범용 클래스 */
+.order-data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+}
+
+.order-data-table th {
+    background-color: #f8fafc;
+    color: var(--text-dark);
+    font-weight: 600;
+    padding: 0.75rem 1rem;
+    border-bottom: 2px solid var(--border-color);
+}
+
+.order-data-table td {
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.text-link {
+    color: var(--primary-green);
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.text-center {
+    text-align: center !important;
+}
+
+.text-right {
+    text-align: right !important;
+}
+
+.font-bold {
+    font-weight: 600;
+}
+
+.text-orange {
+    color: #dd6b20 !important;
+}
+
+.text-green {
+    color: var(--primary-green) !important;
+}
+
+.text-blue {
+    color: #3182ce !important;
+}
+
+.text-muted {
+    color: var(--text-muted) !important;
+}
+
+.text-red {
+    color: var(--accent-red) !important;
+}
+
+.table-badge {
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.table-badge.badge-dark {
+    background-color: #f1f1f1;
+    color: var(--text-muted);
+    border: 1px solid #d1d1d1;
+}
+
+.table-badge.badge-success {
+    background-color: #e6fffa;
+    color: #234e52;
+    border: 1px solid #b2f5ea;
+}
+
+.table-badge.badge-pending {
+    background-color: #fffaf0;
+    color: #7b341e;
+    border: 1px solid #feebc8;
+}
+
+.table-badge.badge-danger {
+    background-color: #fff5f5;
+    color: #742a2a;
+    border: 1px solid #fed7d7;
+}
+
+/* 미디어 쿼리 최적화 처리 */
+@media (max-width: 1300px) {
+    .order-summary-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+
+    .search-filter-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+
+    .filter-btn-group {
+        grid-column: span 2;
+        justify-content: flex-end;
+    }
+}
+
+@media (max-width: 640px) {
+    .order-summary-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .search-filter-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .filter-btn-group {
+        grid-column: span 1;
+    }
+}
+
+
+/* ==========================================================================
+   2. [수정 및 확장] 대시보드 내 검색 조건 필터 카드 레이아웃 정렬 서식
+   ========================================================================== */
+.filter-wrapper-card {
+    background-color: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+/* 4열 분할에서 기간 단위 확장형 3열 배분 구조로 최적화 */
+.search-filter-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr auto;
+    gap: 1.5rem;
+    align-items: flex-end;
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* 기간 범위 데이터 컨테이너 스타일 */
+.group-date-range {
+    width: 100%;
+}
+
+
+
+.date-separator {
+    color: var(--text-muted);
+    font-weight: 600;
+    padding: 0 0.2rem;
+}
+
+.filter-group label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.filter-control {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    font-size: 0.9rem;
+    color: var(--text-dark);
+    background-color: #ffffff;
+    height: 38px;
+    outline: none;
+}
+
+.filter-control:focus {
+    border-color: var(--primary-green);
+}
+
+.filter-btn-group {
+    display: flex;
+    gap: 0.5rem;
+    height: 38px;
+}
+
+.btn-filter-reset {
+    background-color: #edf2f7;
+    color: #4a5568;
+    border: none;
+    padding: 0 1.2rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+
+
+/* 태블릿/모바일 등 작은 화면에서의 반응형 브레이크포인트 자동 재배치 */
+@media (max-width: 1024px) {
+    .search-filter-grid {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+
+    .date-range-container {
+        flex-direction: row;
+    }
+
+    .filter-btn-group {
+        justify-content: flex-end;
+        margin-top: 0.5rem;
+    }
+}
+
+/* ==========================================================================
+   3. [신규 추가] 신규 주문 입력 모달 팝업 UI 서식
+   ========================================================================== */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+}
+
+.modal-overlay.active {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.modal-container {
+    background-color: #ffffff;
+    width: 680px;
+    max-width: 90%;
+    border-radius: 8px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    max-height: 85vh;
+    animation: modalSlideUp 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes modalSlideUp {
+    from {
+        transform: translateY(20px);
+        opacity: 0;
+    }
+
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+.modal-header {
+    padding: 1.2rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h3 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.modal-close-btn {
+    background: none;
+    border: none;
+    font-size: 1.75rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    line-height: 1;
+}
+
+.modal-close-btn:hover {
+    color: var(--accent-red);
+}
+
+.modal-body {
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+
+/* 폼 마스터 그리드 */
+.modal-form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.form-group label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.required {
+    color: var(--accent-red);
+    margin-left: 0.1rem;
+}
+
+/* 공통 입력 엘리먼트 서식 */
+.modal-input,
+.modal-select {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #cbd5e0;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    color: var(--text-dark);
+    height: 38px;
+    outline: none;
+    background-color: #ffffff;
+}
+
+.modal-input:focus,
+.modal-select:focus {
+    border-color: var(--primary-green);
+    box-shadow: 0 0 0 2px rgba(3, 169, 77, 0.15);
+}
+
+/* 섹션 타이틀 및 가변 제어 버튼 트랙 */
+.modal-section-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.5rem;
+}
+
+.modal-section-title h4 {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.btn-secondary-sm {
+    background-color: #ffffff;
+    color: var(--primary-green);
+    border: 1px solid var(--primary-green);
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-secondary-sm:hover {
+    background-color: rgba(3, 169, 77, 0.05);
+}
+
+/* 팝업 테이블 서식 */
+.modal-table-responsive {
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.modal-product-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.modal-product-table th {
+    background-color: #f8fafc;
+    color: #4a5568;
+    font-weight: 600;
+    font-size: 0.85rem;
+    padding: 0.6rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-product-table td {
+    padding: 0.5rem;
+    border-bottom: 1px solid var(--border-color);
+    vertical-align: middle;
+}
+
+.modal-product-table tr:last-child td {
+    border-bottom: none;
+}
+
+/* 정렬 헬퍼 클래스 */
+.text-right {
+    text-align: right;
+}
+
+.text-center {
+    text-align: center;
+}
+
+/* 행 삭제 x 버튼 */
+.btn-delete-row {
+    background: none;
+    border: none;
+    color: #a0aec0;
+    font-size: 1.4rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 0.5rem;
+}
+
+.btn-delete-row:hover {
+    color: var(--accent-red);
+}
+
+/* 모달 하단 버튼 액션 바 */
+.modal-footer {
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    background-color: #f8fafc;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+}
+
+.btn-pop-cancel {
+    background-color: #ffffff;
+    color: #4a5568;
+    border: 1px solid #cbd5e0;
+    padding: 0.55rem 1.2rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-pop-cancel:hover {
+    background-color: #edf2f7;
+}
+
+.btn-pop-submit {
+    background-color: var(--primary-green);
+    color: white;
+    border: none;
+    padding: 0.55rem 1.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-pop-submit:hover {
+    background-color: var(--primary-hover);
+}
+
+
+
+
+/* ==========================================================================
+   주문 상세 팝업 좌우 2분할 레이아웃 및 바코드 스타일 스타일시트
+   ========================================================================== */
+
+/* 좌우 분할 그리드 스케일 */
+.modal-split-layout {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 1.25rem;
+    border-top: 1px solid var(--border-color);
+    padding-top: 1rem;
+}
+
+.modal-split-left,
+.modal-split-right {
+    display: flex;
+    flex-direction: column;
+}
+
+/* 테이블 클릭 이펙트 스타일 */
+.clickable-table tbody tr:hover {
+    background-color: #f7fafc;
+}
+
+.clickable-table tbody tr.selected-row {
+    background-color: #e6fffa !important;
+    border-left: 3px solid var(--primary-green);
+}
+
+/* 우측 송장 카드 디자인 박스 */
+.invoice-preview-card {
+    background-color: #f8fafc;
+    border: 1px dashed #cbd5e0;
+    border-radius: 6px;
+    padding: 1.25rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 280px;
+}
+
+.empty-invoice-msg {
+    text-align: center;
+    color: #a0aec0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.invoice-box-inner {
+    width: 100%;
+    background: #ffffff;
+    border: 1px solid #cbd5e0;
+    border-radius: 4px;
+    padding: 1rem;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.03);
+}
+
+.invoice-header-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #2d3748;
+    text-align: center;
+    border-bottom: 2px dashed #e2e8f0;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.invoice-mini-table {
+    width: 100%;
+    margin-bottom: 1rem;
+    border-collapse: collapse;
+}
+
+.invoice-mini-table th {
+    background-color: #f1f5f9 !important;
+    color: #4a5568;
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.4rem 0.6rem;
+    width: 30%;
+    text-align: left !important;
+    border: 1px solid #e2e8f0;
+}
+
+.invoice-mini-table td {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.85rem;
+    color: #2d3748;
+    text-align: left !important;
+    border: 1px solid #e2e8f0;
+}
+
+/* CSS 바코드 모듈 그래픽 생성 컴포넌트 */
+.barcode-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: white;
+    padding: 0.75rem 0.5rem;
+    border: 1px solid #e2e8f0;
+    margin-top: 0.5rem;
+}
+
+.barcode-lines {
+    display: flex;
+    align-items: stretch;
+    height: 45px;
+    background: #000;
+}
+
+/* 바코드 선 두께 유틸리티 배열 */
+.barcode-lines span {
+    display: inline-block;
+    background: #fff;
+    height: 100%;
+}
+
+.barcode-lines .b-w-1 {
+    width: 1px;
+    background: #000;
+}
+
+.barcode-lines .b-w-2 {
+    width: 3px;
+    background: #000;
+}
+
+.barcode-lines .b-w-3 {
+    width: 2px;
+    background: #fff;
+}
+
+.barcode-lines .b-w-4 {
+    width: 4px;
+    background: #fff;
+}
+
+.barcode-text {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.75rem;
+    font-weight: bold;
+    letter-spacing: 2px;
+    margin-top: 0.25rem;
+    color: #1a202c;
+}
+
+.invoice-footer-action {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.75rem;
+    border-top: 1px solid #e2e8f0;
+    padding-top: 0.5rem;
+}
+
+
+/* ==========================================================================
+   추가 배송 설정 제어존 및 송장 생성 버튼 스타일
+   ========================================================================== */
+
+/* 배송 설정 컨테이너 컴포넌트 */
+.delivery-config-zone {
+    background-color: #f8fafc;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1rem;
+}
+
+.config-form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.config-form-row .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.config-form-row label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.select-styled {
+    height: 36px;
+    padding: 0 0.5rem;
+    font-size: 0.85rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: #ffffff;
+    color: var(--text-dark);
+}
+
+.select-styled:focus {
+    border-color: var(--primary-green);
+    outline: none;
+}
+
+/* 송장 생성 전용 대형 버튼 */
+.action-btn-wrap {
+    margin-top: 0.5rem;
+}
+
+.btn-generate-invoice {
+    width: 100%;
+    background-color: var(--primary-green);
+    color: #ffffff;
+    border: none;
+    padding: 0.75rem;
+    font-size: 0.95rem;
+    font-weight: 700;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.1s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    box-shadow: 0 2px 4px rgba(3, 169, 77, 0.15);
+}
+
+.btn-generate-invoice:hover {
+    background-color: var(--primary-hover);
+}
+
+.btn-generate-invoice:active {
+    transform: scale(0.99);
+}
+
+/* 우측 송장 카드 박스 내부 정렬 보정 */
+.invoice-preview-card {
+    min-height: 380px;
+    /* 늘어난 정보량에 대응하도록 최소 높이 확장 */
+}
+
+.view-toggle-container {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 0.5rem;
+}
+
+.btn-toggle-view {
+    background-color: #ffffff;
+    color: #4a5568;
+    border: 1px solid var(--border-color);
+    padding: 0.5rem 1.5rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-toggle-view:hover {
+    background-color: #f8fafc;
+}
+
+.btn-toggle-view.active {
+    background-color: var(--primary-green);
+    color: #ffffff;
+    border-color: var(--primary-green);
+}
+
+/* 테이블 뷰 숨김 제어 */
+.table-view-content {
+    display: none;
+}
+
+.table-view-content.active {
+    display: block;
+}
+
+.toggle-left,
+.toggle-right {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.view-toggle-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.btn-action-gray,
+.btn-action-blue,
+.btn-action-green {
+    border: none;
+    padding: 0.55rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    color: #fff;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.btn-action-gray {
+    background: #64748b;
+}
+
+.btn-action-blue {
+    background: #2563eb;
+}
+
+.btn-action-green {
+    background: #16a34a;
+}
+
+.btn-filter-search {
+    margin-left: auto;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #28   

## 📝 작업 내용
- 출고/송장 outbound, 출고이력 outhistory 화면만 추가

## 💬 리뷰 포인트
- 촐고이력 상세 모달이 입고 이력 상세 모달과 동일하여 제외.
- outbound.css, outhistory.css 충돌 확인 필요.
- 출고/송장 모달로 구현되어 있어 포함하지 않음.
 
