### PR TITLE
Feature/출고송장 api 수정 (#25)

### DIFF
--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundController.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundController.java
@@ -26,6 +26,8 @@ public class OutboundController implements OutboundControllerDocs {
     /**
      * 박스 뷰 목록 조회
      * POST /outbound
+     * - OUTBOUND_PACKING 기준 목록
+     * - 필터: 주문번호(outboundId), 고객사명, 상태, 날짜 범위
      */
     @PostMapping
     public ResponseDTO findAll(@RequestBody OutboundRequestDTO outboundRequestDTO) {
@@ -33,7 +35,7 @@ public class OutboundController implements OutboundControllerDocs {
     }
 
     /**
-     * 주문 상세 내역 조회 (제품 목록 포함)
+     * 주문 상세 조회 (OUTBOUND 단건 + ORDER_PRODUCT 목록)
      * POST /outbound/{outboundId}
      */
     @PostMapping("/{outboundId:[0-9]+}")
@@ -44,6 +46,7 @@ public class OutboundController implements OutboundControllerDocs {
     /**
      * 매니페스트 뷰 목록 조회
      * POST /outbound/manifest
+     * - OUTBOUND_TRANSPORTATION 기준 목록
      */
     @PostMapping("/manifest")
     public ResponseDTO findAllManifest(@RequestBody OutboundRequestDTO outboundRequestDTO) {
@@ -51,8 +54,9 @@ public class OutboundController implements OutboundControllerDocs {
     }
 
     /**
-     * 폼 데이터 조회 (운송사·차량 목록)
+     * 폼 데이터 조회 (차량 배정 모달 드롭다운용)
      * GET /outbound
+     * - 운송사 목록 (carrier_yn_code=1), 차량 목록
      */
     @GetMapping
     public ResponseDTO findAllOutbound() {
@@ -62,6 +66,7 @@ public class OutboundController implements OutboundControllerDocs {
     /**
      * 차량 배정
      * PUT /outbound/vehicle
+     * - OUTBOUND_TRANSPORTATION INSERT → OUTBOUND_PACKING.outbound_transportation_id UPDATE
      */
     @PutMapping("/vehicle")
     public ResponseDTO assignVehicle(@RequestBody OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
@@ -69,8 +74,10 @@ public class OutboundController implements OutboundControllerDocs {
     }
 
     /**
-     * 송장 발급
+     * 송장 발급 (운송장번호 저장)
      * PUT /outbound/invoice
+     * - OUTBOUND_PACKING.invoice_number UPDATE
+     * - OUTBOUND_PACKING.state_code 변경
      */
     @PutMapping("/invoice")
     public ResponseDTO issueInvoice(@RequestBody OutboundInvoiceDTO outboundInvoiceDTO) {
@@ -80,6 +87,9 @@ public class OutboundController implements OutboundControllerDocs {
     /**
      * 출고 확정
      * PUT /outbound/confirm
+     * - OUTBOUND_TRANSPORTATION.state_code UPDATE (출고완료)
+     * - OUTBOUND_TRANSPORTATION.atd = NOW()
+     * ※ 매니페스트 탭에서 매니페스트 단위로 확정 처리
      */
     @PutMapping("/confirm")
     public ResponseDTO confirmShipment(@RequestBody OutboundConfirmDTO outboundConfirmDTO) {

--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundController.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundController.java
@@ -1,12 +1,17 @@
 package cloud.weareithero.api.outbound;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 import cloud.weareithero.api.outbound.service.OutboundService;
 import cloud.weareithero.dto.ResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +41,59 @@ public class OutboundController implements OutboundControllerDocs {
     @PostMapping("/{outboundId:[0-9]+}")
     public ResponseDTO findOne(@PathVariable Integer outboundId) {
         return outboundService.findOne(outboundId);
+    }
+
+    /**
+     * 매니페스트 뷰 목록 조회
+     * POST /outbound/manifest
+     * - OUTBOUND_TRANSPORTATION 기준 목록
+     */
+    @PostMapping("/manifest")
+    public ResponseDTO findAllManifest(@RequestBody OutboundRequestDTO outboundRequestDTO) {
+        return outboundService.findAllManifest(outboundRequestDTO);
+    }
+
+    /**
+     * 폼 데이터 조회 (차량 배정 모달 드롭다운용)
+     * GET /outbound
+     * - 운송사 목록 (carrier_yn_code=1), 차량 목록
+     */
+    @GetMapping
+    public ResponseDTO findAllOutbound() {
+        return outboundService.findAllOutbound();
+    }
+
+    /**
+     * 차량 배정
+     * PUT /outbound/vehicle
+     * - OUTBOUND_TRANSPORTATION INSERT → OUTBOUND_PACKING.outbound_transportation_id UPDATE
+     */
+    @PutMapping("/vehicle")
+    public ResponseDTO assignVehicle(@RequestBody OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
+        return outboundService.assignVehicle(outboundVehicleAssignDTO);
+    }
+
+    /**
+     * 송장 발급 (운송장번호 저장)
+     * PUT /outbound/invoice
+     * - OUTBOUND_PACKING.invoice_number UPDATE
+     * - OUTBOUND_PACKING.state_code 변경
+     */
+    @PutMapping("/invoice")
+    public ResponseDTO issueInvoice(@RequestBody OutboundInvoiceDTO outboundInvoiceDTO) {
+        return outboundService.issueInvoice(outboundInvoiceDTO);
+    }
+
+    /**
+     * 출고 확정
+     * PUT /outbound/confirm
+     * - OUTBOUND_TRANSPORTATION.state_code UPDATE (출고완료)
+     * - OUTBOUND_TRANSPORTATION.atd = NOW()
+     * ※ 매니페스트 탭에서 매니페스트 단위로 확정 처리
+     */
+    @PutMapping("/confirm")
+    public ResponseDTO confirmShipment(@RequestBody OutboundConfirmDTO outboundConfirmDTO) {
+        return outboundService.confirmShipment(outboundConfirmDTO);
     }
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundController.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundController.java
@@ -1,0 +1,89 @@
+package cloud.weareithero.api.outbound;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
+import cloud.weareithero.api.outbound.service.OutboundService;
+import cloud.weareithero.dto.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/outbound")
+@RequiredArgsConstructor
+public class OutboundController implements OutboundControllerDocs {
+
+    private final OutboundService outboundService;
+
+    /**
+     * 박스 뷰 목록 조회
+     * POST /outbound
+     */
+    @PostMapping
+    public ResponseDTO findAll(@RequestBody OutboundRequestDTO outboundRequestDTO) {
+        return outboundService.findAll(outboundRequestDTO);
+    }
+
+    /**
+     * 주문 상세 내역 조회 (제품 목록 포함)
+     * POST /outbound/{outboundId}
+     */
+    @PostMapping("/{outboundId:[0-9]+}")
+    public ResponseDTO findOne(@PathVariable Integer outboundId) {
+        return outboundService.findOne(outboundId);
+    }
+
+    /**
+     * 매니페스트 뷰 목록 조회
+     * POST /outbound/manifest
+     */
+    @PostMapping("/manifest")
+    public ResponseDTO findAllManifest(@RequestBody OutboundRequestDTO outboundRequestDTO) {
+        return outboundService.findAllManifest(outboundRequestDTO);
+    }
+
+    /**
+     * 폼 데이터 조회 (운송사·차량 목록)
+     * GET /outbound
+     */
+    @GetMapping
+    public ResponseDTO findAllOutbound() {
+        return outboundService.findAllOutbound();
+    }
+
+    /**
+     * 차량 배정
+     * PUT /outbound/vehicle
+     */
+    @PutMapping("/vehicle")
+    public ResponseDTO assignVehicle(@RequestBody OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
+        return outboundService.assignVehicle(outboundVehicleAssignDTO);
+    }
+
+    /**
+     * 송장 발급
+     * PUT /outbound/invoice
+     */
+    @PutMapping("/invoice")
+    public ResponseDTO issueInvoice(@RequestBody OutboundInvoiceDTO outboundInvoiceDTO) {
+        return outboundService.issueInvoice(outboundInvoiceDTO);
+    }
+
+    /**
+     * 출고 확정
+     * PUT /outbound/confirm
+     */
+    @PutMapping("/confirm")
+    public ResponseDTO confirmShipment(@RequestBody OutboundConfirmDTO outboundConfirmDTO) {
+        return outboundService.confirmShipment(outboundConfirmDTO);
+    }
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundController.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundController.java
@@ -1,17 +1,12 @@
 package cloud.weareithero.api.outbound;
 
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
-import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 import cloud.weareithero.api.outbound.service.OutboundService;
 import cloud.weareithero.dto.ResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -41,59 +36,6 @@ public class OutboundController implements OutboundControllerDocs {
     @PostMapping("/{outboundId:[0-9]+}")
     public ResponseDTO findOne(@PathVariable Integer outboundId) {
         return outboundService.findOne(outboundId);
-    }
-
-    /**
-     * 매니페스트 뷰 목록 조회
-     * POST /outbound/manifest
-     * - OUTBOUND_TRANSPORTATION 기준 목록
-     */
-    @PostMapping("/manifest")
-    public ResponseDTO findAllManifest(@RequestBody OutboundRequestDTO outboundRequestDTO) {
-        return outboundService.findAllManifest(outboundRequestDTO);
-    }
-
-    /**
-     * 폼 데이터 조회 (차량 배정 모달 드롭다운용)
-     * GET /outbound
-     * - 운송사 목록 (carrier_yn_code=1), 차량 목록
-     */
-    @GetMapping
-    public ResponseDTO findAllOutbound() {
-        return outboundService.findAllOutbound();
-    }
-
-    /**
-     * 차량 배정
-     * PUT /outbound/vehicle
-     * - OUTBOUND_TRANSPORTATION INSERT → OUTBOUND_PACKING.outbound_transportation_id UPDATE
-     */
-    @PutMapping("/vehicle")
-    public ResponseDTO assignVehicle(@RequestBody OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
-        return outboundService.assignVehicle(outboundVehicleAssignDTO);
-    }
-
-    /**
-     * 송장 발급 (운송장번호 저장)
-     * PUT /outbound/invoice
-     * - OUTBOUND_PACKING.invoice_number UPDATE
-     * - OUTBOUND_PACKING.state_code 변경
-     */
-    @PutMapping("/invoice")
-    public ResponseDTO issueInvoice(@RequestBody OutboundInvoiceDTO outboundInvoiceDTO) {
-        return outboundService.issueInvoice(outboundInvoiceDTO);
-    }
-
-    /**
-     * 출고 확정
-     * PUT /outbound/confirm
-     * - OUTBOUND_TRANSPORTATION.state_code UPDATE (출고완료)
-     * - OUTBOUND_TRANSPORTATION.atd = NOW()
-     * ※ 매니페스트 탭에서 매니페스트 단위로 확정 처리
-     */
-    @PutMapping("/confirm")
-    public ResponseDTO confirmShipment(@RequestBody OutboundConfirmDTO outboundConfirmDTO) {
-        return outboundService.confirmShipment(outboundConfirmDTO);
     }
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundControllerDocs.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundControllerDocs.java
@@ -1,0 +1,87 @@
+package cloud.weareithero.api.outbound;
+
+import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
+import cloud.weareithero.docs.ApiCommonErrors;
+import cloud.weareithero.docs.ApiCommonSuccess;
+import cloud.weareithero.dto.ResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "출고/송장 관리", description = "출고 목록 조회 · 매니페스트 조회 · 차량 배정 · 송장 발급 · 출고 확정 API")
+public interface OutboundControllerDocs {
+
+    @Operation(summary = "출고 박스 목록 조회", description = "Outbound API")
+    @ApiCommonSuccess
+    @ApiCommonErrors
+    public ResponseDTO findAll(@RequestBody(
+        content = @Content(
+            schema = @Schema(implementation = OutboundRequestDTO.class),
+            examples = {
+                @ExampleObject(
+                    name = "1. 전체 검색 예시",
+                    value = OutboundResponseExamples.FIND_ALL_DEFAULT,
+                    description = "전체 기간 동안의 출고 박스 목록을 조회할 때 사용합니다."
+                ),
+                @ExampleObject(
+                    name = "2. 날짜 범위 + 상태 검색 예시",
+                    value = OutboundResponseExamples.FIND_ALL_FILTER,
+                    description = "특정 기간 및 진행 상태로 필터링할 때 사용합니다."
+                ),
+                @ExampleObject(
+                    name = "3. 주문번호 검색 예시",
+                    value = OutboundResponseExamples.FIND_ALL_BY_ORDER,
+                    description = "주문번호로 검색할 때 사용합니다."
+                )
+            }
+        ))
+        OutboundRequestDTO outboundRequestDTO);
+
+    @Operation(summary = "출고 주문 상세 조회", description = "Outbound API")
+    @ApiCommonSuccess
+    @ApiCommonErrors
+    public ResponseDTO findOne(Integer outboundId);
+
+    @Operation(summary = "매니페스트 목록 조회", description = "Outbound API")
+    @ApiCommonSuccess
+    @ApiCommonErrors
+    public ResponseDTO findAllManifest(@RequestBody(
+        content = @Content(
+            schema = @Schema(implementation = OutboundRequestDTO.class),
+            examples = {
+                @ExampleObject(
+                    name = "1. 전체 검색 예시",
+                    value = OutboundResponseExamples.FIND_ALL_DEFAULT,
+                    description = "전체 매니페스트 목록을 조회합니다."
+                )
+            }
+        ))
+        OutboundRequestDTO outboundRequestDTO);
+
+    @Operation(summary = "출고 폼 데이터 조회 (운송사·차량 목록)", description = "Outbound API")
+    @ApiCommonSuccess
+    @ApiCommonErrors
+    public ResponseDTO findAllOutbound();
+
+    @Operation(summary = "차량 배정", description = "Outbound API")
+    @ApiCommonSuccess
+    @ApiCommonErrors
+    public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
+
+    @Operation(summary = "송장 발급", description = "Outbound API")
+    @ApiCommonSuccess
+    @ApiCommonErrors
+    public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
+
+    @Operation(summary = "출고 확정", description = "Outbound API")
+    @ApiCommonSuccess
+    @ApiCommonErrors
+    public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO);
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundControllerDocs.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundControllerDocs.java
@@ -14,10 +14,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "출고/송장 관리", description = "출고 목록 조회 · 매니페스트 조회 · 차량 배정 · 송장 발급 · 출고 확정 API")
+@Tag(name = "Outbound 출고 관리", description = "박스 목록 조회 · 매니페스트 조회 · 차량 배정 · 송장 발급 · 출고 확정 API")
 public interface OutboundControllerDocs {
 
-    @Operation(summary = "출고 박스 목록 조회", description = "Outbound API")
+    @Operation(summary = "출고 박스 목록 조회", description = "OUTBOUND_PACKING 기준 박스 뷰 목록 + 상단 집계 카드 + 페이지네이션")
     @ApiCommonSuccess
     @ApiCommonErrors
     public ResponseDTO findAll(@RequestBody(
@@ -25,30 +25,30 @@ public interface OutboundControllerDocs {
             schema = @Schema(implementation = OutboundRequestDTO.class),
             examples = {
                 @ExampleObject(
-                    name = "1. 전체 검색 예시",
+                    name = "1. 전체 조회",
                     value = OutboundResponseExamples.FIND_ALL_DEFAULT,
-                    description = "전체 기간 동안의 출고 박스 목록을 조회할 때 사용합니다."
+                    description = "조건 없이 전체 박스 목록 조회"
                 ),
                 @ExampleObject(
-                    name = "2. 날짜 범위 + 상태 검색 예시",
+                    name = "2. 날짜 + 상태 필터",
                     value = OutboundResponseExamples.FIND_ALL_FILTER,
-                    description = "특정 기간 및 진행 상태로 필터링할 때 사용합니다."
+                    description = "기간 및 상태 필터 조회"
                 ),
                 @ExampleObject(
-                    name = "3. 주문번호 검색 예시",
-                    value = OutboundResponseExamples.FIND_ALL_BY_ORDER,
-                    description = "주문번호로 검색할 때 사용합니다."
+                    name = "3. 주문번호 검색",
+                    value = OutboundResponseExamples.FIND_ALL_BY_OUTBOUND,
+                    description = "주문번호(OUTBOUND.id) 기준 검색"
                 )
             }
         ))
         OutboundRequestDTO outboundRequestDTO);
 
-    @Operation(summary = "출고 주문 상세 조회", description = "Outbound API")
+    @Operation(summary = "출고 주문 상세 조회", description = "OUTBOUND 단건 헤더 + ORDER_PRODUCT 목록")
     @ApiCommonSuccess
     @ApiCommonErrors
     public ResponseDTO findOne(Integer outboundId);
 
-    @Operation(summary = "매니페스트 목록 조회", description = "Outbound API")
+    @Operation(summary = "매니페스트 목록 조회", description = "OUTBOUND_TRANSPORTATION 기준 매니페스트 뷰 + 페이지네이션")
     @ApiCommonSuccess
     @ApiCommonErrors
     public ResponseDTO findAllManifest(@RequestBody(
@@ -56,30 +56,30 @@ public interface OutboundControllerDocs {
             schema = @Schema(implementation = OutboundRequestDTO.class),
             examples = {
                 @ExampleObject(
-                    name = "1. 전체 검색 예시",
+                    name = "1. 전체 조회",
                     value = OutboundResponseExamples.FIND_ALL_DEFAULT,
-                    description = "전체 매니페스트 목록을 조회합니다."
+                    description = "전체 매니페스트 목록 조회"
                 )
             }
         ))
         OutboundRequestDTO outboundRequestDTO);
 
-    @Operation(summary = "출고 폼 데이터 조회 (운송사·차량 목록)", description = "Outbound API")
+    @Operation(summary = "출고 폼 데이터 조회", description = "차량 배정 모달용 운송사·차량 드롭다운 데이터")
     @ApiCommonSuccess
     @ApiCommonErrors
     public ResponseDTO findAllOutbound();
 
-    @Operation(summary = "차량 배정", description = "Outbound API")
+    @Operation(summary = "차량 배정", description = "OUTBOUND_TRANSPORTATION INSERT 후 OUTBOUND_PACKING 일괄 UPDATE")
     @ApiCommonSuccess
     @ApiCommonErrors
     public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
 
-    @Operation(summary = "송장 발급", description = "Outbound API")
+    @Operation(summary = "송장 발급", description = "OUTBOUND_PACKING.invoice_number 저장 + 상태 변경")
     @ApiCommonSuccess
     @ApiCommonErrors
     public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
 
-    @Operation(summary = "출고 확정", description = "Outbound API")
+    @Operation(summary = "출고 확정", description = "OUTBOUND_TRANSPORTATION 출고완료 처리 + atd 기록")
     @ApiCommonSuccess
     @ApiCommonErrors
     public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO);

--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundResponseExamples.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundResponseExamples.java
@@ -1,0 +1,44 @@
+package cloud.weareithero.api.outbound;
+
+public interface OutboundResponseExamples {
+
+    final String FIND_ALL_DEFAULT = """
+        {
+          "outboundId": 0,
+          "orderNo": "",
+          "customerName": "",
+          "stateCode": 0,
+          "orderStart": "",
+          "orderEnd": "",
+          "page": 1,
+          "size": 20
+        }
+        """;
+
+    final String FIND_ALL_FILTER = """
+        {
+          "outboundId": 0,
+          "orderNo": "",
+          "customerName": "",
+          "stateCode": 6,
+          "orderStart": "2026-05-20",
+          "orderEnd": "2026-06-25",
+          "page": 1,
+          "size": 20
+        }
+        """;
+
+    final String FIND_ALL_BY_ORDER = """
+        {
+          "outboundId": 0,
+          "orderNo": "PO-20260602",
+          "customerName": "",
+          "stateCode": 0,
+          "orderStart": "",
+          "orderEnd": "",
+          "page": 1,
+          "size": 20
+        }
+        """;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundResponseExamples.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundResponseExamples.java
@@ -20,18 +20,18 @@ public interface OutboundResponseExamples {
           "outboundId": 0,
           "orderNo": "",
           "customerName": "",
-          "stateCode": 6,
-          "orderStart": "2026-05-20",
-          "orderEnd": "2026-06-25",
+          "stateCode": 1,
+          "orderStart": "2026-06-01",
+          "orderEnd": "2026-06-30",
           "page": 1,
           "size": 20
         }
         """;
 
-    final String FIND_ALL_BY_ORDER = """
+    final String FIND_ALL_BY_OUTBOUND = """
         {
-          "outboundId": 0,
-          "orderNo": "PO-20260602",
+          "outboundId": 1,
+          "orderNo": "",
           "customerName": "",
           "stateCode": 0,
           "orderStart": "",

--- a/backend/src/main/java/cloud/weareithero/api/outbound/OutboundResponseExamples.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/OutboundResponseExamples.java
@@ -5,7 +5,6 @@ public interface OutboundResponseExamples {
     final String FIND_ALL_DEFAULT = """
         {
           "outboundId": 0,
-          "orderNo": "",
           "customerName": "",
           "stateCode": 0,
           "orderStart": "",
@@ -18,7 +17,6 @@ public interface OutboundResponseExamples {
     final String FIND_ALL_FILTER = """
         {
           "outboundId": 0,
-          "orderNo": "",
           "customerName": "",
           "stateCode": 1,
           "orderStart": "2026-06-01",
@@ -31,7 +29,6 @@ public interface OutboundResponseExamples {
     final String FIND_ALL_BY_OUTBOUND = """
         {
           "outboundId": 1,
-          "orderNo": "",
           "customerName": "",
           "stateCode": 0,
           "orderStart": "",

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDao.java
@@ -1,0 +1,42 @@
+package cloud.weareithero.api.outbound.dao;
+
+import java.util.List;
+
+import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
+import cloud.weareithero.api.outbound.dto.OutboundDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
+import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
+import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
+
+public interface OutboundDao {
+
+    public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO);
+
+    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO);
+
+    public OutboundDTO findByOutboundId(int outboundId);
+
+    public List<OutboundProductDTO> findProducts(int outboundId);
+
+    public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO);
+
+    public List<OutboundCarrierDTO> findByCarrier();
+
+    public List<OutboundTransportationVehicleDTO> findByVehicle();
+
+    // 차량 배정: OUTBOUND_TRANSPORTATION INSERT → 생성된 PK 반환
+    public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
+
+    // 차량 배정: 개별 OUTBOUND에 transportationId 연결 UPDATE
+    public int updateTransportationId(int outboundId, int transportationId);
+
+    public int updateInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
+
+    // 출고 확정: state_code UPDATE
+    public int updateStateCode(int outboundId, int stateCode);
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDao.java
@@ -6,6 +6,7 @@ import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
 import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
 import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
 import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
@@ -14,29 +15,40 @@ import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 
 public interface OutboundDao {
 
+    /** OUTBOUND 기준 집계 5종 */
     public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO);
 
-    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO);
+    /** OUTBOUND_PACKING 박스 목록 (필터 + 페이지네이션) */
+    public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO);
 
+    /** OUTBOUND 단건 조회 */
     public OutboundDTO findByOutboundId(int outboundId);
 
+    /** OUTBOUND_PACKING 단건 조회 (상태 가드용) */
+    public OutboundPackingDTO findByPackingId(int packingId);
+
+    /** ORDER_PRODUCT 목록 조회 */
     public List<OutboundProductDTO> findProducts(int outboundId);
 
+    /** OUTBOUND_TRANSPORTATION 기준 매니페스트 목록 */
     public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO);
 
+    /** 운송사 목록 (carrier_yn_code = 1) */
     public List<OutboundCarrierDTO> findByCarrier();
 
+    /** 차량 목록 */
     public List<OutboundTransportationVehicleDTO> findByVehicle();
 
-    // 차량 배정: OUTBOUND_TRANSPORTATION INSERT → 생성된 PK 반환
+    /** OUTBOUND_TRANSPORTATION INSERT - useGeneratedKeys로 transportationId 반환 */
     public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
 
-    // 차량 배정: 개별 OUTBOUND에 transportationId 연결 UPDATE
-    public int updateTransportationId(int outboundId, int transportationId);
+    /** OUTBOUND_PACKING에 transportationId 연결 UPDATE */
+    public int updatePackingTransportation(int packingId, int transportationId);
 
-    public int updateInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
+    /** OUTBOUND_PACKING invoice_number + state_code UPDATE */
+    public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO);
 
-    // 출고 확정: state_code UPDATE
-    public int updateStateCode(int outboundId, int stateCode);
+    /** OUTBOUND_TRANSPORTATION 출고확정 UPDATE (state_code + atd) */
+    public int updateTransportationConfirm(int transportationId, int stateCode);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDao.java
@@ -2,18 +2,53 @@ package cloud.weareithero.api.outbound.dao;
 
 import java.util.List;
 
+import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
+import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 
 public interface OutboundDao {
 
-    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO);
+    /** OUTBOUND 기준 집계 5종 */
+    public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO);
 
-    int countAll(OutboundRequestDTO outboundRequestDTO);
+    /** OUTBOUND_PACKING 박스 목록 (필터 + 페이지네이션) */
+    public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO);
 
-    public List<OutboundProductDTO> findOne(int outboundId);
+    /** OUTBOUND 단건 조회 */
+    public OutboundDTO findByOutboundId(int outboundId);
 
-    public OutboundDTO findbyOutboundId(int outboundId);
+    /** OUTBOUND_PACKING 단건 조회 (상태 가드용) */
+    public OutboundPackingDTO findByPackingId(int packingId);
+
+    /** ORDER_PRODUCT 목록 조회 */
+    public List<OutboundProductDTO> findProducts(int outboundId);
+
+    /** OUTBOUND_TRANSPORTATION 기준 매니페스트 목록 */
+    public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO);
+
+    /** 운송사 목록 (carrier_yn_code = 1) */
+    public List<OutboundCarrierDTO> findByCarrier();
+
+    /** 차량 목록 */
+    public List<OutboundTransportationVehicleDTO> findByVehicle();
+
+    /** OUTBOUND_TRANSPORTATION INSERT - useGeneratedKeys로 transportationId 반환 */
+    public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
+
+    /** OUTBOUND_PACKING에 transportationId 연결 UPDATE */
+    public int updatePackingTransportation(int packingId, int transportationId, int stateCode);
+
+    /** OUTBOUND_PACKING invoice_number + state_code UPDATE */
+    public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO);
+
+    /** OUTBOUND_TRANSPORTATION 출고확정 UPDATE (state_code + atd) */
+    public int updateTransportationConfirm(int transportationId, int stateCode);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDao.java
@@ -2,53 +2,18 @@ package cloud.weareithero.api.outbound.dao;
 
 import java.util.List;
 
-import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
-import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
-import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
-import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
-import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 
 public interface OutboundDao {
 
-    /** OUTBOUND 기준 집계 5종 */
-    public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO);
+    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO);
 
-    /** OUTBOUND_PACKING 박스 목록 (필터 + 페이지네이션) */
-    public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO);
+    int countAll(OutboundRequestDTO outboundRequestDTO);
 
-    /** OUTBOUND 단건 조회 */
-    public OutboundDTO findByOutboundId(int outboundId);
+    public List<OutboundProductDTO> findOne(int outboundId);
 
-    /** OUTBOUND_PACKING 단건 조회 (상태 가드용) */
-    public OutboundPackingDTO findByPackingId(int packingId);
-
-    /** ORDER_PRODUCT 목록 조회 */
-    public List<OutboundProductDTO> findProducts(int outboundId);
-
-    /** OUTBOUND_TRANSPORTATION 기준 매니페스트 목록 */
-    public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO);
-
-    /** 운송사 목록 (carrier_yn_code = 1) */
-    public List<OutboundCarrierDTO> findByCarrier();
-
-    /** 차량 목록 */
-    public List<OutboundTransportationVehicleDTO> findByVehicle();
-
-    /** OUTBOUND_TRANSPORTATION INSERT - useGeneratedKeys로 transportationId 반환 */
-    public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
-
-    /** OUTBOUND_PACKING에 transportationId 연결 UPDATE */
-    public int updatePackingTransportation(int packingId, int transportationId);
-
-    /** OUTBOUND_PACKING invoice_number + state_code UPDATE */
-    public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO);
-
-    /** OUTBOUND_TRANSPORTATION 출고확정 UPDATE (state_code + atd) */
-    public int updateTransportationConfirm(int transportationId, int stateCode);
+    public OutboundDTO findbyOutboundId(int outboundId);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDaoImp.java
@@ -4,11 +4,20 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
+import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class OutboundDaoImp implements OutboundDao {
@@ -16,22 +25,66 @@ public class OutboundDaoImp implements OutboundDao {
     private final OutboundMapper outboundMapper;
 
     @Override
-    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO) {
+    public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO) {
+        return outboundMapper.findSummary(outboundRequestDTO);
+    }
+
+    @Override
+    public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO) {
         return outboundMapper.findAll(outboundRequestDTO);
     }
 
     @Override
-    public int countAll(OutboundRequestDTO outboundRequestDTO) {
-        return outboundMapper.countAll(outboundRequestDTO);
+    public OutboundDTO findByOutboundId(int outboundId) {
+        return outboundMapper.findByOutboundId(outboundId);
     }
 
     @Override
-    public List<OutboundProductDTO> findOne(int outboundId) {
-        return outboundMapper.findOne(outboundId);
+    public OutboundPackingDTO findByPackingId(int packingId) {
+        return outboundMapper.findByPackingId(packingId);
     }
 
     @Override
-    public OutboundDTO findbyOutboundId(int outboundId) {
-        return outboundMapper.findbyOutboundId(outboundId);
+    public List<OutboundProductDTO> findProducts(int outboundId) {
+        return outboundMapper.findProducts(outboundId);
     }
+
+    @Override
+    public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO) {
+        return outboundMapper.findAllManifest(outboundRequestDTO);
+    }
+
+    @Override
+    public List<OutboundCarrierDTO> findByCarrier() {
+        return outboundMapper.findByCarrier();
+    }
+
+    @Override
+    public List<OutboundTransportationVehicleDTO> findByVehicle() {
+        return outboundMapper.findByVehicle();
+    }
+
+    @Override
+    public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
+        outboundMapper.addTransportation(outboundVehicleAssignDTO);
+        // @Options(useGeneratedKeys = true, keyProperty = "transportationId") 로 PK 자동
+        // 주입
+        return outboundVehicleAssignDTO.getTransportationId();
+    }
+
+    @Override
+    public int updatePackingTransportation(int packingId, int transportationId, int stateCode) {
+        return outboundMapper.updatePackingTransportation(packingId, transportationId, stateCode);
+    }
+
+    @Override
+    public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO) {
+        return outboundMapper.updateInvoiceNumber(outboundInvoiceDTO);
+    }
+
+    @Override
+    public int updateTransportationConfirm(int transportationId, int stateCode) {
+        return outboundMapper.updateTransportationConfirm(transportationId, stateCode);
+    }
+
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDaoImp.java
@@ -1,0 +1,83 @@
+package cloud.weareithero.api.outbound.dao;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
+import cloud.weareithero.api.outbound.dto.OutboundDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
+import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
+import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class OutboundDaoImp implements OutboundDao {
+
+    private final OutboundMapper outboundMapper;
+
+    @Override
+    public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO) {
+        return outboundMapper.findSummary(outboundRequestDTO);
+    }
+
+    @Override
+    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO) {
+        return outboundMapper.findAll(outboundRequestDTO);
+    }
+
+    @Override
+    public OutboundDTO findByOutboundId(int outboundId) {
+        return outboundMapper.findByOutboundId(outboundId);
+    }
+
+    @Override
+    public List<OutboundProductDTO> findProducts(int outboundId) {
+        return outboundMapper.findProducts(outboundId);
+    }
+
+    @Override
+    public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO) {
+        return outboundMapper.findAllManifest(outboundRequestDTO);
+    }
+
+    @Override
+    public List<OutboundCarrierDTO> findByCarrier() {
+        return outboundMapper.findByCarrier();
+    }
+
+    @Override
+    public List<OutboundTransportationVehicleDTO> findByVehicle() {
+        return outboundMapper.findByVehicle();
+    }
+
+    @Override
+    public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
+        outboundMapper.addTransportation(outboundVehicleAssignDTO);
+        // @Options(useGeneratedKeys = true, keyProperty = "transportationId") 로 PK 주입
+        return outboundVehicleAssignDTO.getTransportationId();
+    }
+
+    @Override
+    public int updateTransportationId(int outboundId, int transportationId) {
+        return outboundMapper.updateTransportationId(outboundId, transportationId);
+    }
+
+    @Override
+    public int updateInvoice(OutboundInvoiceDTO outboundInvoiceDTO) {
+        return outboundMapper.updateInvoice(outboundInvoiceDTO);
+    }
+
+    @Override
+    public int updateStateCode(int outboundId, int stateCode) {
+        return outboundMapper.updateStateCode(outboundId, stateCode);
+    }
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDaoImp.java
@@ -8,6 +8,7 @@ import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
 import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
 import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
 import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
@@ -29,13 +30,18 @@ public class OutboundDaoImp implements OutboundDao {
     }
 
     @Override
-    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO) {
+    public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO) {
         return outboundMapper.findAll(outboundRequestDTO);
     }
 
     @Override
     public OutboundDTO findByOutboundId(int outboundId) {
         return outboundMapper.findByOutboundId(outboundId);
+    }
+
+    @Override
+    public OutboundPackingDTO findByPackingId(int packingId) {
+        return outboundMapper.findByPackingId(packingId);
     }
 
     @Override
@@ -61,23 +67,23 @@ public class OutboundDaoImp implements OutboundDao {
     @Override
     public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
         outboundMapper.addTransportation(outboundVehicleAssignDTO);
-        // @Options(useGeneratedKeys = true, keyProperty = "transportationId") 로 PK 주입
+        // @Options(useGeneratedKeys = true, keyProperty = "transportationId") 로 PK 자동 주입
         return outboundVehicleAssignDTO.getTransportationId();
     }
 
     @Override
-    public int updateTransportationId(int outboundId, int transportationId) {
-        return outboundMapper.updateTransportationId(outboundId, transportationId);
+    public int updatePackingTransportation(int packingId, int transportationId) {
+        return outboundMapper.updatePackingTransportation(packingId, transportationId);
     }
 
     @Override
-    public int updateInvoice(OutboundInvoiceDTO outboundInvoiceDTO) {
-        return outboundMapper.updateInvoice(outboundInvoiceDTO);
+    public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO) {
+        return outboundMapper.updateInvoiceNumber(outboundInvoiceDTO);
     }
 
     @Override
-    public int updateStateCode(int outboundId, int stateCode) {
-        return outboundMapper.updateStateCode(outboundId, stateCode);
+    public int updateTransportationConfirm(int transportationId, int stateCode) {
+        return outboundMapper.updateTransportationConfirm(transportationId, stateCode);
     }
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundDaoImp.java
@@ -4,20 +4,11 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
-import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
-import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
-import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
-import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class OutboundDaoImp implements OutboundDao {
@@ -25,65 +16,22 @@ public class OutboundDaoImp implements OutboundDao {
     private final OutboundMapper outboundMapper;
 
     @Override
-    public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO) {
-        return outboundMapper.findSummary(outboundRequestDTO);
-    }
-
-    @Override
-    public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO) {
+    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO) {
         return outboundMapper.findAll(outboundRequestDTO);
     }
 
     @Override
-    public OutboundDTO findByOutboundId(int outboundId) {
-        return outboundMapper.findByOutboundId(outboundId);
+    public int countAll(OutboundRequestDTO outboundRequestDTO) {
+        return outboundMapper.countAll(outboundRequestDTO);
     }
 
     @Override
-    public OutboundPackingDTO findByPackingId(int packingId) {
-        return outboundMapper.findByPackingId(packingId);
+    public List<OutboundProductDTO> findOne(int outboundId) {
+        return outboundMapper.findOne(outboundId);
     }
 
     @Override
-    public List<OutboundProductDTO> findProducts(int outboundId) {
-        return outboundMapper.findProducts(outboundId);
+    public OutboundDTO findbyOutboundId(int outboundId) {
+        return outboundMapper.findbyOutboundId(outboundId);
     }
-
-    @Override
-    public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO) {
-        return outboundMapper.findAllManifest(outboundRequestDTO);
-    }
-
-    @Override
-    public List<OutboundCarrierDTO> findByCarrier() {
-        return outboundMapper.findByCarrier();
-    }
-
-    @Override
-    public List<OutboundTransportationVehicleDTO> findByVehicle() {
-        return outboundMapper.findByVehicle();
-    }
-
-    @Override
-    public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
-        outboundMapper.addTransportation(outboundVehicleAssignDTO);
-        // @Options(useGeneratedKeys = true, keyProperty = "transportationId") 로 PK 자동 주입
-        return outboundVehicleAssignDTO.getTransportationId();
-    }
-
-    @Override
-    public int updatePackingTransportation(int packingId, int transportationId) {
-        return outboundMapper.updatePackingTransportation(packingId, transportationId);
-    }
-
-    @Override
-    public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO) {
-        return outboundMapper.updateInvoiceNumber(outboundInvoiceDTO);
-    }
-
-    @Override
-    public int updateTransportationConfirm(int transportationId, int stateCode) {
-        return outboundMapper.updateTransportationConfirm(transportationId, stateCode);
-    }
-
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
@@ -2,92 +2,471 @@ package cloud.weareithero.api.outbound.dao;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
+import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
+import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 
 @Mapper
 public interface OutboundMapper {
 
-    @Select("<script>" +
-        """
-        SELECT
-            `o`.`atd` AS atd,
-            `o`.`id` AS outboundId,
-            `pcm`.`id` AS partnerId,
-            `pcm`.`name` AS partnerName,
-            `wm`.`id` AS warehouseId,
-            `wm`.`name` AS warehouseName
-        FROM `OUTBOUND` `o`
-        JOIN `PARTNER_COMPANY_MASTER` `pcm`
-            ON(`o`.`partner_company_id` = `pcm`.`id`)
-        JOIN `WAREHOUSE_MASTER` `wm`
-            ON(`o`.`warehouse_id` = `wm`.`id`)
-        JOIN `COMMON_CODE` `cc`
-            ON(`o`.`state_code` = `cc`.`id`)
-        """ +
-        "<where>" +
-        " AND `cc`.`name` = '출고완료' " +
-        "<if test='orderStart != null and orderStart != \"\" and orderEnd != null and orderEnd != \"\"'>" +
-        " AND `o`.`atd` BETWEEN STR_TO_DATE(#{orderStart}, '%Y-%m-%d') AND STR_TO_DATE(#{orderEnd}, '%Y-%m-%d') " +
-        "</if>" +
-        "<if test='outboundId != null and outboundId != 0'>" +
-        " AND `o`.`id` LIKE CONCAT('%', #{outboundId}, '%') " +
-        "</if>" +
-        "</where> " +
-        "ORDER BY `o`.`id` DESC LIMIT #{offset}, #{size} " +
-        "</script>")
-    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO);
+  /**
+   * 1. 출고 화면 상단 집계 카드 5종
+   * 기준 테이블: OUTBOUND (JOIN ORDER_PRODUCT_LIST 없음 - 3차안 기준 OUTBOUND 직접 partner_company_id 보유)
+   *
+   * 집계 항목:
+   *   total         - 전체 OUTBOUND 건수
+   *   expectedToday - 당일 etd 기준 미완료 건 (OUTBOUND.etd = CURDATE(), state_code != 완료)
+   *   confirmedToday- OUTBOUND_TRANSPORTATION.atd 기준 당일 출고 완료 건
+   *                   (OUTBOUND_PACKING → OUTBOUND_TRANSPORTATION 경유 서브쿼리)
+   *   nearDeadline  - OUTBOUND.deadline 기준 3일 이내 미완료 건
+   *                   TODO: 기한 임박 기준 일수(현재 3일) 팀 협의 후 확정 필요
+   *   overdue       - OUTBOUND.deadline < CURDATE() 미완료 건
+   *   unassigned    - OUTBOUND_PACKING.outbound_transportation_id IS NULL 건
+   *
+   * 동적 조건:
+   *   outboundId   - OUTBOUND.id LIKE
+   *   customerName - PARTNER_COMPANY_MASTER.name LIKE
+   *   stateCode    - OUTBOUND.state_code =
+   *   orderStart/orderEnd - OUTBOUND.order_date BETWEEN
+   *
+   * TODO: '완료' state_code 정수값 확인 필요 (현재 CASE WHEN state_code != 9 로 임시 처리)
+   *       OrderMapper 기준 9 = 출고완료 이므로 동일 체계라면 9 사용 가능, COMMON_CODE 확인 필요
+   */
+  @Select("<script>" +
+      """
+          SELECT
+            COUNT(DISTINCT `ob`.`id`) AS `total`,
+            SUM(CASE WHEN DATE(`ob`.`etd`) = CURDATE()
+                          AND `ob`.`state_code` != 9
+                     THEN 1 ELSE 0 END) AS `expectedToday`,
+            SUM(CASE WHEN EXISTS (
+                       SELECT 1
+                       FROM `OUTBOUND_PACKING` `op2`
+                       JOIN `OUTBOUND_TRANSPORTATION` `ot2`
+                         ON `op2`.`outbound_transportation_id` = `ot2`.`id`
+                       WHERE `op2`.`outbound_id` = `ob`.`id`
+                         AND DATE(`ot2`.`atd`) = CURDATE()
+                     ) THEN 1 ELSE 0 END) AS `confirmedToday`,
+            SUM(CASE WHEN DATEDIFF(`ob`.`deadline`, CURDATE()) BETWEEN 0 AND 3
+                          AND `ob`.`state_code` != 9
+                     THEN 1 ELSE 0 END) AS `nearDeadline`,
+            SUM(CASE WHEN `ob`.`deadline` &lt; CURDATE()
+                          AND `ob`.`state_code` != 9
+                     THEN 1 ELSE 0 END) AS `overdue`,
+            SUM(CASE WHEN EXISTS (
+                       SELECT 1
+                       FROM `OUTBOUND_PACKING` `op3`
+                       WHERE `op3`.`outbound_id` = `ob`.`id`
+                         AND `op3`.`outbound_transportation_id` IS NULL
+                     ) THEN 1 ELSE 0 END) AS `unassigned`
+          FROM `OUTBOUND` `ob`
+          JOIN `PARTNER_COMPANY_MASTER` `pcm`
+            ON `ob`.`partner_company_id` = `pcm`.`id`
+          """ +
+      "<where>" +
+      "<if test='orderStart != null and orderStart != \"\" and orderEnd != null and orderEnd != \"\"'>" +
+      " AND `ob`.`order_date` BETWEEN #{orderStart} AND #{orderEnd} " +
+      "</if>" +
+      "<if test='outboundId != null and outboundId != 0'>" +
+      " AND `ob`.`id` LIKE CONCAT('%', #{outboundId}, '%') " +
+      "</if>" +
+      "<if test='customerName != null and customerName != \"\"'>" +
+      " AND `pcm`.`name` LIKE CONCAT('%', #{customerName}, '%') " +
+      "</if>" +
+      "<if test='stateCode != null and stateCode != 0'>" +
+      " AND `ob`.`state_code` = #{stateCode} " +
+      "</if>" +
+      "</where>" +
+      "</script>")
+  public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO);
 
-    @Select("<script>" +
-        "SELECT COUNT(*) FROM `OUTBOUND` `o` " +
-        "JOIN `COMMON_CODE` `cc` ON `o`.`state_code` = `cc`.`id` " +
-        "WHERE `cc`.`name` = '출고완료' " +
-        "<if test='orderStart != null and orderStart != \"\" and orderEnd != null and orderEnd != \"\"'>" +
-        " AND `o`.`atd` BETWEEN STR_TO_DATE(#{orderStart}, '%Y-%m-%d')" +
-        " AND STR_TO_DATE(CONCAT(#{orderEnd}, ' 23:59:59'), '%Y-%m-%d %H:%i:%s') " +
-        "</if>" +
-        "<if test='outboundId != null and outboundId != 0'>" +
-        " AND `o`.`id` = #{outboundId} " +
-        "</if>" +
-        "</script>")
-    int countAll(OutboundRequestDTO outboundRequestDTO);
+  /**
+   * 2. 박스 뷰 목록 조회 (OUTBOUND_PACKING 기준, 페이지네이션 포함)
+   *
+   * JOIN 경로:
+   *   OUTBOUND_PACKING op
+   *     → OUTBOUND ob                          ON op.outbound_id = ob.id
+   *       → PARTNER_COMPANY_MASTER pcm         ON ob.partner_company_id = pcm.id  (고객사)
+   *     → PARTNER_COMPANY_MASTER carrier       ON op.partner_company_id = carrier.id  (운송사, LEFT JOIN)
+   *       ※ OUTBOUND_PACKING.partner_company_id = 운송사 FK (DB 설계서 확인됨)
+   *     → OUTBOUND_TRANSPORTATION ot           ON op.outbound_transportation_id = ot.id (LEFT JOIN)
+   *     → COMMON_CODE cc                       ON op.state_code = cc.id
+   *
+   * DTO alias 매핑:
+   *   packingId             ← op.id
+   *   packingInvoiceNumber  ← op.packing_invoice_number  (박스번호)
+   *   outboundId            ← op.outbound_id             (주문번호)
+   *   customerName          ← pcm.name
+   *   carrierName           ← carrier.name               (미배정 시 NULL)
+   *   invoiceNumber         ← op.invoice_number          (송장 발급 전 NULL)
+   *   stateCode             ← op.state_code
+   *   stateName             ← cc.name
+   *   deadline              ← ob.deadline
+   *   etd                   ← ob.etd
+   *   transportationId      ← op.outbound_transportation_id (미배정 시 NULL)
+   *
+   * 동적 조건: Inbound findAll 패턴 동일 적용
+   * ORDER BY op.id DESC, LIMIT #{offset}, #{size}
+   */
+  @Select("<script>" +
+      """
+          SELECT
+            `op`.`id`                              AS `packingId`,
+            `op`.`packing_invoice_number`          AS `packingInvoiceNumber`,
+            `op`.`outbound_id`                     AS `outboundId`,
+            `pcm`.`name`                           AS `customerName`,
+            `carrier`.`name`                       AS `carrierName`,
+            `op`.`invoice_number`                  AS `invoiceNumber`,
+            `op`.`state_code`                      AS `stateCode`,
+            `cc`.`name`                            AS `stateName`,
+            `ob`.`deadline`                        AS `deadline`,
+            `ob`.`etd`                             AS `etd`,
+            `op`.`outbound_transportation_id`      AS `transportationId`
+          FROM `OUTBOUND_PACKING` `op`
+          JOIN `OUTBOUND` `ob`
+            ON `op`.`outbound_id` = `ob`.`id`
+          JOIN `PARTNER_COMPANY_MASTER` `pcm`
+            ON `ob`.`partner_company_id` = `pcm`.`id`
+          LEFT JOIN `PARTNER_COMPANY_MASTER` `carrier`
+            ON `op`.`partner_company_id` = `carrier`.`id`
+          LEFT JOIN `OUTBOUND_TRANSPORTATION` `ot`
+            ON `op`.`outbound_transportation_id` = `ot`.`id`
+          JOIN `COMMON_CODE` `cc`
+            ON `op`.`state_code` = `cc`.`id`
+          """ +
+      "<where>" +
+      "<if test='orderStart != null and orderStart != \"\" and orderEnd != null and orderEnd != \"\"'>" +
+      " AND `ob`.`order_date` BETWEEN #{orderStart} AND #{orderEnd} " +
+      "</if>" +
+      "<if test='outboundId != null and outboundId != 0'>" +
+      " AND `ob`.`id` LIKE CONCAT('%', #{outboundId}, '%') " +
+      "</if>" +
+      "<if test='customerName != null and customerName != \"\"'>" +
+      " AND `pcm`.`name` LIKE CONCAT('%', #{customerName}, '%') " +
+      "</if>" +
+      "<if test='stateCode != null and stateCode != 0'>" +
+      " AND `op`.`state_code` = #{stateCode} " +
+      "</if>" +
+      "</where>" +
+      "ORDER BY `op`.`id` DESC LIMIT #{offset}, #{size}" +
+      "</script>")
+  public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO);
 
-    @Select("""
-        SELECT
-            op.`id` AS `no`,
-            op.`outbound_id` AS `outboundId`,
-            op.`material_id` AS `itemNo`,
-            mm.`name` AS `itemName`,
-            mm.`alloy_type` AS `alloyType`,
-            op.`weight_kg` AS `weight`
-        FROM `highgooh`.`ORDER_PRODUCT` AS op
-        INNER JOIN `highgooh`.`MATERIAL_MASTER` AS mm
-        ON (op.`material_id` = mm.`id`)
-        WHERE op.`outbound_id` = #{outboundId}
-            """)
-    public List<OutboundProductDTO> findOne(int outboundId);
+  /**
+   * 3. OUTBOUND_PACKING 단건 조회 (issueInvoice 상태 가드용)
+   *
+   * JOIN: COMMON_CODE (state_code 명칭)
+   * WHERE OUTBOUND_PACKING.id = #{packingId}
+   */
+  @Select("""
+      SELECT
+        `op`.`id`                              AS `packingId`,
+        `op`.`packing_invoice_number`          AS `packingInvoiceNumber`,
+        `op`.`outbound_id`                     AS `outboundId`,
+        `op`.`invoice_number`                  AS `invoiceNumber`,
+        `op`.`state_code`                      AS `stateCode`,
+        `cc`.`name`                            AS `stateName`,
+        `op`.`outbound_transportation_id`      AS `transportationId`
+      FROM `OUTBOUND_PACKING` `op`
+      JOIN `COMMON_CODE` `cc`
+        ON `op`.`state_code` = `cc`.`id`
+      WHERE `op`.`id` = #{packingId}
+      """)
+  public OutboundPackingDTO findByPackingId(int packingId);
 
-    @Select("""
-        SELECT
-            `o`.`atd` AS atd,
-            `o`.`id` AS outboundId,
-            `pcm`.`id` AS partnerId,
-            `pcm`.`name` AS partnerName,
-            `wm`.`id` AS warehouseId,
-            `wm`.`name` AS warehouseName
-        FROM `OUTBOUND` `o`
-        JOIN `PARTNER_COMPANY_MASTER` `pcm`
-            ON(`o`.`partner_company_id` = `pcm`.`id`)
-        JOIN `WAREHOUSE_MASTER` `wm`
-            ON(`o`.`warehouse_id` = `wm`.`id`)
-        JOIN `COMMON_CODE` `cc`
-            ON(`o`.`state_code` = `cc`.`id`)
-        WHERE `o`.`id` = #{outboundId}
-        """)
-    public OutboundDTO findbyOutboundId(int outboundId);
+  /**
+   * 4. OUTBOUND 단건 조회 (상세 모달 헤더용)
+   *
+   * JOIN 경로:
+   *   OUTBOUND ob
+   *     → PARTNER_COMPANY_MASTER pcm ON ob.partner_company_id = pcm.id  (고객사)
+   *     → COMMON_CODE cc             ON ob.state_code = cc.id
+   *
+   * DTO alias 매핑:
+   *   outboundId  ← ob.id
+   *   partnerId   ← ob.partner_company_id
+   *   partnerName ← pcm.name
+   *   orderDate   ← ob.order_date
+   *   deadline    ← ob.deadline
+   *   etd         ← ob.etd
+   *   stateCode   ← ob.state_code
+   *   stateName   ← cc.name
+   */
+  @Select("""
+      SELECT
+        `ob`.`id`                    AS `outboundId`,
+        `ob`.`partner_company_id`    AS `partnerId`,
+        `pcm`.`name`                 AS `partnerName`,
+        `ob`.`order_date`            AS `orderDate`,
+        `ob`.`deadline`              AS `deadline`,
+        `ob`.`etd`                   AS `etd`,
+        `ob`.`state_code`            AS `stateCode`,
+        `cc`.`name`                  AS `stateName`
+      FROM `OUTBOUND` `ob`
+      JOIN `PARTNER_COMPANY_MASTER` `pcm`
+        ON `ob`.`partner_company_id` = `pcm`.`id`
+      LEFT JOIN `COMMON_CODE` `cc`
+        ON `ob`.`state_code` = `cc`.`id`
+      WHERE `ob`.`id` = #{outboundId}
+      """)
+  public OutboundDTO findByOutboundId(int outboundId);
+
+  /**
+   * 5. ORDER_PRODUCT 목록 조회 (상세 모달 제품 목록)
+   *
+   * JOIN 경로:
+   *   ORDER_PRODUCT op
+   *     → OUTBOUND_PRODUCT_MASTER opm ON op.outbound_product_id = opm.id
+   *
+   * WHERE op.outbound_id = #{outboundId}
+   *   ※ 3차안 기준 ORDER_PRODUCT.outbound_id → OUTBOUND.id 직접 연결
+   *      (이전 설계의 order_product_list_id 사용 안 함)
+   *
+   * DTO alias 매핑:
+   *   productId   ← op.id
+   *   productName ← opm.name
+   *   quantity    ← op.quantity
+   *   price       ← op.price
+   *   totalPrice  ← op.total_price
+   */
+  @Select("""
+      SELECT
+        `op`.`id`            AS `productId`,
+        `opm`.`name`         AS `productName`,
+        `op`.`quantity`      AS `quantity`,
+        `op`.`price`         AS `price`,
+        `op`.`total_price`   AS `totalPrice`
+      FROM `ORDER_PRODUCT` `op`
+      JOIN `OUTBOUND_PRODUCT_MASTER` `opm`
+        ON `op`.`outbound_product_id` = `opm`.`id`
+      WHERE `op`.`outbound_id` = #{outboundId}
+      """)
+  public List<OutboundProductDTO> findProducts(int outboundId);
+
+  /**
+   * 6. 매니페스트 뷰 목록 조회 (OUTBOUND_TRANSPORTATION 기준, 페이지네이션 포함)
+   *
+   * JOIN 경로:
+   *   OUTBOUND_TRANSPORTATION ot
+   *     → PARTNER_COMPANY_MASTER carrier  ON ot.carrier_company_id = carrier.id
+   *     → TRANSPORTATION_VEHICLE_MASTER tvm ON ot.transportation_vehicle_id = tvm.id
+   *     → OUTBOUND_PACKING op             ON op.outbound_transportation_id = ot.id (LEFT JOIN)
+   *       → OUTBOUND ob                  ON op.outbound_id = ob.id (LEFT JOIN, 필터용)
+   *         → PARTNER_COMPANY_MASTER pcm ON ob.partner_company_id = pcm.id (LEFT JOIN, customerName 필터용)
+   *     → COMMON_CODE cc                  ON ot.state_code = cc.id
+   *
+   * GROUP BY ot.id (OUTBOUND_PACKING COUNT 집계)
+   *
+   * DTO alias 매핑:
+   *   transportationId ← ot.id
+   *   manifestNo       ← CONCAT('MNF-', LPAD(ot.id, 6, '0'))  (별도 컬럼 없음, 가공)
+   *   carrierName      ← carrier.name
+   *   vehicleInfo      ← CONCAT(ot.lpn, ' (', tvm.vehicle_type, ')')
+   *   boxCount         ← COUNT(op.id)
+   *   stateCode        ← ot.state_code
+   *   stateName        ← cc.name
+   *   etd              ← ot.etd
+   *   atd              ← ot.atd
+   *   driver           ← ot.driver
+   *
+   * 동적 조건:
+   *   stateCode    - ot.state_code = (HAVING 대신 WHERE 적용 - GROUP 전 필터)
+   *   customerName - pcm.name LIKE (LEFT JOIN 후 WHERE 적용)
+   *   orderStart/orderEnd - ob.order_date BETWEEN (LEFT JOIN 후 WHERE 적용)
+   * ORDER BY ot.id DESC, LIMIT #{offset}, #{size}
+   */
+  @Select("<script>" +
+      """
+          SELECT
+            `ot`.`id`                                                       AS `transportationId`,
+            CONCAT('MNF-', LPAD(`ot`.`id`, 6, '0'))                        AS `manifestNo`,
+            `carrier`.`name`                                                AS `carrierName`,
+            CONCAT(`ot`.`lpn`, ' (', `tvm`.`vehicle_type`, ')')            AS `vehicleInfo`,
+            COUNT(`op`.`id`)                                                AS `boxCount`,
+            `ot`.`state_code`                                               AS `stateCode`,
+            `cc`.`name`                                                     AS `stateName`,
+            `ot`.`etd`                                                      AS `etd`,
+            `ot`.`atd`                                                      AS `atd`,
+            `ot`.`driver`                                                   AS `driver`
+          FROM `OUTBOUND_TRANSPORTATION` `ot`
+          JOIN `PARTNER_COMPANY_MASTER` `carrier`
+            ON `ot`.`carrier_company_id` = `carrier`.`id`
+          JOIN `TRANSPORTATION_VEHICLE_MASTER` `tvm`
+            ON `ot`.`transportation_vehicle_id` = `tvm`.`id`
+          LEFT JOIN `OUTBOUND_PACKING` `op`
+            ON `op`.`outbound_transportation_id` = `ot`.`id`
+          LEFT JOIN `OUTBOUND` `ob`
+            ON `op`.`outbound_id` = `ob`.`id`
+          LEFT JOIN `PARTNER_COMPANY_MASTER` `pcm`
+            ON `ob`.`partner_company_id` = `pcm`.`id`
+          JOIN `COMMON_CODE` `cc`
+            ON `ot`.`state_code` = `cc`.`id`
+          """ +
+      "<where>" +
+      "<if test='stateCode != null and stateCode != 0'>" +
+      " AND `ot`.`state_code` = #{stateCode} " +
+      "</if>" +
+      "<if test='customerName != null and customerName != \"\"'>" +
+      " AND `pcm`.`name` LIKE CONCAT('%', #{customerName}, '%') " +
+      "</if>" +
+      "<if test='orderStart != null and orderStart != \"\" and orderEnd != null and orderEnd != \"\"'>" +
+      " AND `ob`.`order_date` BETWEEN #{orderStart} AND #{orderEnd} " +
+      "</if>" +
+      "</where>" +
+      "GROUP BY `ot`.`id`, `carrier`.`name`, `ot`.`lpn`, `tvm`.`vehicle_type`, " +
+      "`ot`.`state_code`, `cc`.`name`, `ot`.`etd`, `ot`.`atd`, `ot`.`driver` " +
+      "ORDER BY `ot`.`id` DESC LIMIT #{offset}, #{size}" +
+      "</script>")
+  public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO);
+
+  /**
+   * 7. 운송사 목록 조회 (차량 배정 모달 드롭다운)
+   * PARTNER_COMPANY_MASTER WHERE carrier_yn_code = 1
+   * Inbound의 findBySupplier (supplier_yn_code = 1) 대칭 구조
+   */
+  @Select("""
+      SELECT
+        `id`,
+        `name`
+      FROM `PARTNER_COMPANY_MASTER`
+      WHERE `carrier_yn_code` = 1
+      """)
+  public List<OutboundCarrierDTO> findByCarrier();
+
+  /**
+   * 8. 차량 목록 조회 (차량 배정 모달 드롭다운)
+   * TRANSPORTATION_VEHICLE_MASTER 전체 조회
+   * ※ 차량 번호판(lpn)은 이 테이블에 없음 → 모달에서 직접 입력 → VehicleAssignDTO.lpn 으로 전달
+   */
+  @Select("""
+      SELECT
+        `id`,
+        `vehicle_type`    AS `vehicleType`,
+        `max_payload_ton` AS `maxPayloadTon`
+      FROM `TRANSPORTATION_VEHICLE_MASTER`
+      """)
+  public List<OutboundTransportationVehicleDTO> findByVehicle();
+
+  /**
+   * 9. 차량 배정 - OUTBOUND_TRANSPORTATION INSERT
+   *
+   * 저장 컬럼:
+   *   carrier_company_id         ← carrierId
+   *   transportation_vehicle_id  ← vehicleId
+   *   lpn                        ← lpn (차량번호 직접 입력)
+   *   driver                     ← driver (기사명)
+   *   etd                        ← etd (예상 출고 일자)
+   *   state_code                 ← stateCode (차량 배정 후 상태 코드)
+   *   updated_at                 ← NOW()
+   *
+   * @Options(useGeneratedKeys = true, keyProperty = "transportationId")
+   * → 생성된 PK를 OutboundVehicleAssignDTO.transportationId 에 자동 주입
+   * → DaoImp.addTransportation() 에서 dto.getTransportationId() 로 읽어 반환
+   *   */
+  @Insert("""
+      INSERT INTO `OUTBOUND_TRANSPORTATION` (
+        `carrier_company_id`,
+        `transportation_vehicle_id`,
+        `lpn`,
+        `driver`,
+        `etd`,
+        `state_code`,
+        `updated_at`
+      ) VALUES (
+        #{carrierId},
+        #{vehicleId},
+        #{lpn},
+        #{driver},
+        #{etd},
+        #{stateCode},
+        NOW()
+      )
+      """)
+  @Options(useGeneratedKeys = true, keyProperty = "transportationId", keyColumn = "id")
+  public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
+
+  /**
+   * 10. 차량 배정 - OUTBOUND_PACKING UPDATE
+   * 선택된 박스(OUTBOUND_PACKING.id)에 transportation_id 연결 + 상태 변경
+   *
+   * SET outbound_transportation_id = #{transportationId}
+   *     state_code = #{stateCode} 
+   *     updated_at = NOW()
+   * WHERE id = #{packingId}
+   *
+   * @Param 으로 두 파라미터 바인딩
+   * TODO: state_code 값 COMMON_CODE 확인 필요
+   */
+  @Update("""
+      UPDATE `OUTBOUND_PACKING`
+      SET
+        `outbound_transportation_id` = #{transportationId},
+        `state_code`                 = #{stateCode},
+        `updated_at`                 = NOW()
+      WHERE `id` = #{packingId}
+      """)
+  public int updatePackingTransportation(@Param("packingId") int packingId,
+                                         @Param("transportationId") int transportationId,
+                                         @Param("stateCode") int stateCode);
+
+  /**
+   * 11. 송장 발급 - OUTBOUND_PACKING UPDATE
+   * invoice_number 저장 + 상태 변경
+   *
+   * SET invoice_number = #{invoiceNumber}  (ServiceImp에서 채번 후 DTO에 주입)
+   *     state_code = TODO: 송장발급완료 state_code 값 COMMON_CODE 확인 후 교체 (현재 임시 0)
+   *     updated_at = NOW()
+   * WHERE id = #{packingId}  (ServiceImp 루프 내 단건 처리)
+   *
+   * [컬럼 구분]
+   *   invoice_number         = 운송장번호 (이 메서드에서 저장)
+   *   packing_invoice_number = 패킹 박스 식별번호 (기존 값, 변경하지 않음)
+   */
+  @Update("""
+      UPDATE `OUTBOUND_PACKING`
+      SET
+        `invoice_number` = #{invoiceNumber},
+        `state_code`     = #{stateCode},
+        `updated_at`     = NOW()
+      WHERE `id` = #{packingId}
+      """)
+  public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO);
+
+  /**
+   * 12. 출고 확정 - OUTBOUND_TRANSPORTATION UPDATE
+   * 매니페스트 단위 출고 확정 처리
+   *
+   * SET state_code = #{stateCode}  (ServiceImp에서 출고완료 코드 전달)
+   *     atd        = NOW()         (실제 출고 일시 기록)
+   *     updated_at = NOW()
+   * WHERE id = #{transportationId}
+   *
+   * @Param 으로 두 파라미터 바인딩
+   * TODO: stateCode = 출고완료 COMMON_CODE id 값 확인 후 ServiceImp 상수 교체 필요
+   */
+  @Update("""
+      UPDATE `OUTBOUND_TRANSPORTATION`
+      SET
+        `state_code`  = #{stateCode},
+        `atd`         = NOW(),
+        `updated_at`  = NOW()
+      WHERE `id` = #{transportationId}
+      """)
+  public int updateTransportationConfirm(@Param("transportationId") int transportationId,
+                                         @Param("stateCode") int stateCode);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
@@ -1,0 +1,199 @@
+package cloud.weareithero.api.outbound.dao;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+
+import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
+import cloud.weareithero.api.outbound.dto.OutboundDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
+import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
+import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
+
+/**
+ * Outbound Mapper Interface
+ *
+ * SQL 구현은 Mapper XML (OutboundMapper.xml)에 작성합니다.
+ * Inbound와 달리 @Select/@Insert 어노테이션 인라인 방식을 사용하지 않고
+ * XML 방식으로 통일합니다. (동적 쿼리가 많고 UPDATE 구문이 다수 포함되어
+ * 가독성을 위해 XML 분리가 적합합니다.)
+ *
+ * namespace: cloud.weareithero.api.outbound.dao.OutboundMapper
+ */
+@Mapper
+public interface OutboundMapper {
+
+    /**
+     * [findSummary]
+     * 상단 집계 카드 5종 조회
+     * 대상 테이블: OUTBOUND (JOIN ORDER_PRODUCT_LIST, PARTNER_COMPANY_MASTER, COMMON_CODE)
+     *
+     * 집계 항목:
+     *   - total         : 전체 건수
+     *   - expectedToday : 출고 예정 (당일 etd 기준, state_code = 출고대기)
+     *   - confirmedToday: 출고 확정 (당일 기준, state_code = 출고확정)
+     *   - nearDeadline  : 기한 임박 (etd - NOW() < N분, 미확정 건)  ← 기준값 팀 정의 필요
+     *   - overdue       : 기한 초과 (etd < NOW(), 미확정 건)
+     *   - unassigned    : 미배정 (transportation_vehicle_id IS NULL 또는 state_code = 미배정)
+     *
+     * ※ 필터 조건(날짜 범위, 주문번호, 고객사명, state_code) 동적 적용 필요
+     * ※ "기한 임박" 기준 시간(분) COMMON_CODE 또는 상수로 정의 필요
+     */
+    public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO);
+
+    /**
+     * [findAll]
+     * 박스 뷰 목록 조회 (페이지네이션 포함)
+     * 대상 테이블: OUTBOUND
+     *   JOIN ORDER_PRODUCT_LIST  ON outbound.order_product_list_id = opl.id
+     *   JOIN PARTNER_COMPANY_MASTER ON opl.partner_company_id = pcm.id
+     *   JOIN OUTBOUND_TRANSPORTATION ON outbound.outbound_transportation_id = ot.id  ← 컬럼명 ERD 확인 필요
+     *   JOIN PARTNER_COMPANY_MASTER carrier ON ot.carrier_company_id = carrier.id    ← 운송사
+     *   JOIN TRANSPORTATION_VEHICLE_MASTER ON ot.transportation_vehicle_id = tvm.id
+     *   JOIN COMMON_CODE ON outbound.state_code = cc.id
+     *
+     * 반환 컬럼:
+     *   outboundId, boxNo(*), orderNo, customerName,
+     *   carrierName, stateCode, stateName,
+     *   invoiceNo(*), expectedDepartureAt(*), deadline(etd)
+     *
+     * ※ (*) 표시 컬럼은 ERD에서 컬럼명 및 존재 여부 확인 필요 (아래 ERD 확인 항목 참고)
+     * ※ 동적 조건: orderStart/orderEnd, orderNo(LIKE), customerName(LIKE), stateCode
+     * ※ 페이지네이션: LIMIT #{offset}, #{size}  (PageRequestDTO.offset 활용)
+     */
+    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO);
+
+    /**
+     * [findByOutboundId]
+     * 단건 조회 (상세 모달 헤더 및 상태 가드용)
+     * 대상 테이블: OUTBOUND (JOIN 동일)
+     * WHERE outbound.id = #{outboundId}
+     */
+    public OutboundDTO findByOutboundId(int outboundId);
+
+    /**
+     * [findProducts]
+     * 주문 상세 모달 - 제품 목록 조회
+     * 대상 테이블: ORDER_PRODUCT
+     *   JOIN OUTBOUND_PRODUCT_MASTER ON op.outbound_product_id = opm.id
+     *   JOIN PRODUCT_PRICE ON opm.id = pp.outbound_product_id
+     * WHERE op.order_product_list_id = #{outboundId}
+     *
+     * 반환 컬럼:
+     *   productName(opm.name), quantity(op.quantity),
+     *   totalPrice(op.total_price), boxQty(*), invoiceNo(*)
+     *
+     * ※ boxQty, invoiceNo 컬럼 ERD 확인 필요
+     */
+    public List<OutboundProductDTO> findProducts(int outboundId);
+
+    /**
+     * [findAllManifest]
+     * 매니페스트 뷰 목록 조회 (OUTBOUND_TRANSPORTATION 기준)
+     * 대상 테이블: OUTBOUND_TRANSPORTATION
+     *   JOIN PARTNER_COMPANY_MASTER carrier ON ot.carrier_company_id = carrier.id
+     *   JOIN TRANSPORTATION_VEHICLE_MASTER ON ot.transportation_vehicle_id = tvm.id
+     *   JOIN COMMON_CODE ON ot.state_code(*)= cc.id   ← state_code 컬럼 ERD 확인 필요
+     *
+     * 반환 컬럼:
+     *   manifestNo(*), carrierName, vehicleInfo(차량번호 + 종류 조합),
+     *   boxCount(COUNT(OUTBOUND) 집계), stateName, expectedDepartureAt(*), deadline
+     *
+     * ※ manifestNo 채번 방식 및 컬럼 ERD 확인 필요
+     * ※ OUTBOUND_TRANSPORTATION에 state_code 컬럼 존재 여부 ERD 확인 필요
+     * ※ 동적 조건: orderStart/orderEnd 적용 범위 확인 필요
+     * ※ 페이지네이션: LIMIT #{offset}, #{size}
+     */
+    public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO);
+
+    /**
+     * [findByCarrier]
+     * 운송사 목록 조회 (차량 배정 모달 드롭다운용)
+     * 대상 테이블: PARTNER_COMPANY_MASTER
+     * WHERE carrier_yn_code = 1  ← carrier_yn_code 컬럼 ERD 확인 필요
+     *                              (Inbound의 supplier_yn_code = 1 대칭 구조)
+     *
+     * 반환 컬럼: id, name
+     */
+    public List<OutboundCarrierDTO> findByCarrier();
+
+    /**
+     * [findByVehicle]
+     * 차량 목록 조회 (차량 배정 모달 드롭다운용)
+     * 대상 테이블: TRANSPORTATION_VEHICLE_MASTER
+     *
+     * 반환 컬럼: id, vehicleType, vehicleNumber(*)(*), maxPayloadTon
+     *
+     * ※ vehicleNumber 컬럼명 ERD 확인 필요 (ERD에 vehicle_type, max_payload_ton, max_volume 확인됨)
+     */
+    public List<OutboundTransportationVehicleDTO> findByVehicle();
+
+    /**
+     * [addTransportation]
+     * 차량 배정 - OUTBOUND_TRANSPORTATION INSERT
+     * @Options(useGeneratedKeys = true, keyProperty = "transportationId") 적용 필수
+     *
+     * INSERT INTO OUTBOUND_TRANSPORTATION (
+     *   transportation_vehicle_id,
+     *   carrier_company_id,
+     *   bpn(*),          ← 예상 출발 일시 컬럼명 ERD 확인 필요
+     *   driver,
+     *   ...              ← 기사 연락처 컬럼 ERD 확인 필요
+     * ) VALUES (...)
+     *
+     * ※ OutboundVehicleAssignDTO.transportationId 에 PK 자동 주입됨
+     */
+    @Options(useGeneratedKeys = true, keyProperty = "transportationId")
+    public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
+
+    /**
+     * [updateTransportationId]
+     * 차량 배정 - 개별 OUTBOUND에 transportation_id 연결 + state_code 변경
+     *
+     * UPDATE OUTBOUND
+     * SET outbound_transportation_id(*) = #{transportationId},
+     *     state_code = [차량배정완료 코드]    ← COMMON_CODE 확인 필요
+     * WHERE id = #{outboundId}
+     *
+     * ※ OUTBOUND 테이블에 transportation 연결 FK 컬럼명 ERD 확인 필요
+     * @Param 어노테이션으로 두 파라미터 바인딩
+     */
+    public int updateTransportationId(@Param("outboundId") int outboundId,
+                                      @Param("transportationId") int transportationId);
+
+    /**
+     * [updateInvoice]
+     * 송장 발급 - OUTBOUND UPDATE
+     *
+     * UPDATE OUTBOUND
+     * SET invoice_no(*) = #{invoiceNo},   ← invoice_no 컬럼 ERD 확인 필요
+     *     state_code    = [송장발급완료 코드]  ← COMMON_CODE 확인 필요
+     * WHERE id = #{outboundId}
+     *
+     * ※ invoiceNo 채번 로직:
+     *   - 옵션 A) SQL 내 DATE_FORMAT + LPAD(COUNT+1) 방식 (동시성 취약)
+     *   - 옵션 B) ServiceImp에서 채번 후 DTO에 담아 전달 (권장)
+     *   → 팀 결정 필요
+     */
+    public int updateInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
+
+    /**
+     * [updateStateCode]
+     * 출고 확정 - state_code 단순 UPDATE
+     *
+     * UPDATE OUTBOUND
+     * SET state_code = #{stateCode}
+     * WHERE id = #{outboundId}
+     *
+     * @Param 어노테이션으로 두 파라미터 바인딩
+     */
+    public int updateStateCode(@Param("outboundId") int outboundId,
+                               @Param("stateCode") int stateCode);
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
@@ -10,6 +10,7 @@ import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
 import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
 import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
 import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
@@ -17,183 +18,264 @@ import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
 import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 
 /**
- * Outbound Mapper Interface
- *
- * SQL 구현은 Mapper XML (OutboundMapper.xml)에 작성합니다.
- * Inbound와 달리 @Select/@Insert 어노테이션 인라인 방식을 사용하지 않고
- * XML 방식으로 통일합니다. (동적 쿼리가 많고 UPDATE 구문이 다수 포함되어
- * 가독성을 위해 XML 분리가 적합합니다.)
- *
+ * OutboundMapper
+ * SQL은 OutboundMapper.xml 에 작성합니다.
  * namespace: cloud.weareithero.api.outbound.dao.OutboundMapper
+ *
+ * ──────────────────────────────────────────────────────────────────
+ * [최신 DB 3차안 기준 OUTBOUND 테이블 구조 요약]
+ *
+ * OUTBOUND
+ *   id, partner_company_id, order_date, deadline, etd, state_code, updated_at
+ *   ※ OUTBOUND가 직접 partner_company_id(고객사) 보유
+ *   ※ 이전 설계의 ORDER_PRODUCT_LIST 테이블 없음
+ *
+ * ORDER_PRODUCT
+ *   id, outbound_id, outbound_product_id, quantity, price, total_price
+ *   ※ outbound_id → OUTBOUND.id 직접 연결
+ *
+ * OUTBOUND_PACKING (박스 단위)
+ *   id, outbound_id, packing_invoice_number, outbound_product_id,
+ *   partner_company_id(운송사FK), invoice_number, outbound_transportation_id,
+ *   state_code, updated_at
+ *   ※ 박스 뷰의 1행 = OUTBOUND_PACKING 1건
+ *   ※ packing_invoice_number: 패킹 송장번호 (박스 식별용)
+ *   ※ invoice_number: 운송장번호 (발급 후 저장)
+ *   ※ partner_company_id: 운송사 FK (carrier_yn_code=1)
+ *   ※ outbound_transportation_id: 차량 배정 후 연결
+ *   ※ "백엔드 작업 중 수정 필요 시 요청 바람" 주석 있음 → 구조 변경 가능성
+ *
+ * OUTBOUND_TRANSPORTATION (매니페스트 단위)
+ *   id, carrier_company_id, transportation_vehicle_id, lpn, driver,
+ *   etd, atd, state_code, updated_at
+ *   ※ 매니페스트 뷰의 1행 = OUTBOUND_TRANSPORTATION 1건
+ *   ※ etd: 예상 출고 일자 (차량 배정 시 입력)
+ *   ※ atd: 실제 출고 일자 (출고 확정 시 NOW())
+ *
+ * PARTNER_COMPANY_MASTER
+ *   id, name, supplier_yn_code, customer_yn_code, carrier_yn_code
+ *   ※ 고객사: customer_yn_code=1, 운송사: carrier_yn_code=1
+ * ──────────────────────────────────────────────────────────────────
  */
 @Mapper
 public interface OutboundMapper {
 
     /**
-     * [findSummary]
-     * 상단 집계 카드 5종 조회
-     * 대상 테이블: OUTBOUND (JOIN ORDER_PRODUCT_LIST, PARTNER_COMPANY_MASTER, COMMON_CODE)
+     * [selectOutboundSummary] → findSummary
+     *
+     * OUTBOUND 기준 상단 집계 카드 5종
      *
      * 집계 항목:
-     *   - total         : 전체 건수
-     *   - expectedToday : 출고 예정 (당일 etd 기준, state_code = 출고대기)
-     *   - confirmedToday: 출고 확정 (당일 기준, state_code = 출고확정)
-     *   - nearDeadline  : 기한 임박 (etd - NOW() < N분, 미확정 건)  ← 기준값 팀 정의 필요
-     *   - overdue       : 기한 초과 (etd < NOW(), 미확정 건)
-     *   - unassigned    : 미배정 (transportation_vehicle_id IS NULL 또는 state_code = 미배정)
+     *   total         - 전체 OUTBOUND 건수
+     *   expectedToday - 당일 etd 기준 미완료 건 (OUTBOUND.etd = CURDATE())
+     *   confirmedToday- 당일 atd 기준 완료 건 (OUTBOUND_TRANSPORTATION.atd = CURDATE())
+     *                   ※ OUTBOUND 직접 atd 없음 → OUTBOUND_PACKING → OUTBOUND_TRANSPORTATION 경로
+     *                   ※ atd는 OUTBOUND_TRANSPORTATION에만 존재
+     *   nearDeadline  - 기한 임박: OUTBOUND.deadline 기준 DATEDIFF 3일 이내 미완료
+     *                   ※ 기준일수(3일) 팀 정의 후 확정
+     *   overdue       - 기한 초과: OUTBOUND.deadline < CURDATE(), 미완료 건
+     *   unassigned    - 미배정: OUTBOUND_PACKING.outbound_transportation_id IS NULL
      *
-     * ※ 필터 조건(날짜 범위, 주문번호, 고객사명, state_code) 동적 적용 필요
-     * ※ "기한 임박" 기준 시간(분) COMMON_CODE 또는 상수로 정의 필요
+     * 동적 조건: orderStart/orderEnd(OUTBOUND.order_date), outboundId(OUTBOUND.id LIKE),
+     *           customerName(PARTNER_COMPANY_MASTER.name LIKE), stateCode(OUTBOUND.state_code)
      */
     public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO);
 
     /**
-     * [findAll]
-     * 박스 뷰 목록 조회 (페이지네이션 포함)
-     * 대상 테이블: OUTBOUND
-     *   JOIN ORDER_PRODUCT_LIST  ON outbound.order_product_list_id = opl.id
-     *   JOIN PARTNER_COMPANY_MASTER ON opl.partner_company_id = pcm.id
-     *   JOIN OUTBOUND_TRANSPORTATION ON outbound.outbound_transportation_id = ot.id  ← 컬럼명 ERD 확인 필요
-     *   JOIN PARTNER_COMPANY_MASTER carrier ON ot.carrier_company_id = carrier.id    ← 운송사
-     *   JOIN TRANSPORTATION_VEHICLE_MASTER ON ot.transportation_vehicle_id = tvm.id
-     *   JOIN COMMON_CODE ON outbound.state_code = cc.id
+     * [selectOutboundList] → findAll
+     *
+     * OUTBOUND_PACKING 박스 목록 (페이지네이션 포함)
+     *
+     * JOIN 경로:
+     *   OUTBOUND_PACKING op
+     *     → OUTBOUND ob               ON op.outbound_id = ob.id
+     *       → PARTNER_COMPANY_MASTER pcm  ON ob.partner_company_id = pcm.id (고객사)
+     *     → PARTNER_COMPANY_MASTER carrier ON op.partner_company_id = carrier.id (운송사, LEFT JOIN)
+     *       ※ op.partner_company_id = 운송사 FK (DB 설계 확인됨)
+     *     → OUTBOUND_TRANSPORTATION ot  ON op.outbound_transportation_id = ot.id (LEFT JOIN)
+     *     → COMMON_CODE cc              ON op.state_code = cc.id
      *
      * 반환 컬럼:
-     *   outboundId, boxNo(*), orderNo, customerName,
-     *   carrierName, stateCode, stateName,
-     *   invoiceNo(*), expectedDepartureAt(*), deadline(etd)
+     *   packingId(op.id), packingInvoiceNumber(packing_invoice_number),
+     *   outboundId(ob.id), customerName(pcm.name), carrierName(carrier.name),
+     *   invoiceNumber(op.invoice_number), stateCode(op.state_code), stateName(cc.name),
+     *   deadline(ob.deadline), etd(ob.etd), transportationId(op.outbound_transportation_id)
      *
-     * ※ (*) 표시 컬럼은 ERD에서 컬럼명 및 존재 여부 확인 필요 (아래 ERD 확인 항목 참고)
-     * ※ 동적 조건: orderStart/orderEnd, orderNo(LIKE), customerName(LIKE), stateCode
-     * ※ 페이지네이션: LIMIT #{offset}, #{size}  (PageRequestDTO.offset 활용)
+     * ※ 동적 조건: outboundId(ob.id LIKE), customerName(pcm.name LIKE),
+     *              orderStart/orderEnd(ob.order_date), stateCode(op.state_code)
+     * ※ ORDER BY op.id DESC, LIMIT #{offset}, #{size}
+     *
+     * [화면-DB 불일치 주의]
+     * - JSX의 boxNo 필드 = op.packing_invoice_number 로 매핑
+     * - JSX의 orderNo 필드 = ob.id (OUTBOUND.id) 로 매핑
+     *   ('PO-YYYYMMDD-' 형식 표현이 필요하면 CONCAT 가공 또는 프론트 처리)
+     * - JSX의 due 필드 = ob.deadline 기준으로 프론트가 계산 (백엔드는 날짜 반환)
      */
-    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO);
+    public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO);
 
     /**
-     * [findByOutboundId]
-     * 단건 조회 (상세 모달 헤더 및 상태 가드용)
-     * 대상 테이블: OUTBOUND (JOIN 동일)
-     * WHERE outbound.id = #{outboundId}
+     * [selectOutboundDetail] → findByOutboundId
+     *
+     * OUTBOUND 단건 조회 (상세 모달 헤더용)
+     *
+     * JOIN 경로:
+     *   OUTBOUND ob
+     *     → PARTNER_COMPANY_MASTER pcm ON ob.partner_company_id = pcm.id
+     *     → COMMON_CODE cc             ON ob.state_code = cc.id
+     *
+     * WHERE ob.id = #{outboundId}
      */
     public OutboundDTO findByOutboundId(int outboundId);
 
     /**
-     * [findProducts]
-     * 주문 상세 모달 - 제품 목록 조회
-     * 대상 테이블: ORDER_PRODUCT
-     *   JOIN OUTBOUND_PRODUCT_MASTER ON op.outbound_product_id = opm.id
-     *   JOIN PRODUCT_PRICE ON opm.id = pp.outbound_product_id
-     * WHERE op.order_product_list_id = #{outboundId}
+     * [selectPackingDetail] → findByPackingId
+     *
+     * OUTBOUND_PACKING 단건 조회 (issueInvoice 상태 가드용)
+     * WHERE id = #{packingId}
+     */
+    public OutboundPackingDTO findByPackingId(int packingId);
+
+    /**
+     * [selectOrderProducts] → findProducts
+     *
+     * ORDER_PRODUCT 목록 조회 (상세 모달 제품 목록)
+     *
+     * JOIN 경로:
+     *   ORDER_PRODUCT op
+     *     → OUTBOUND_PRODUCT_MASTER opm ON op.outbound_product_id = opm.id
+     *
+     * WHERE op.outbound_id = #{outboundId}
      *
      * 반환 컬럼:
-     *   productName(opm.name), quantity(op.quantity),
-     *   totalPrice(op.total_price), boxQty(*), invoiceNo(*)
+     *   productId(op.id), productName(opm.name),
+     *   quantity(op.quantity), price(op.price), totalPrice(op.total_price)
      *
-     * ※ boxQty, invoiceNo 컬럼 ERD 확인 필요
+     * ※ DB 설계상 ORDER_PRODUCT에 box_id 없음 → boxQty 산출 불가
+     *   OUTBOUND_PACKING.outbound_product_id 로 연결은 가능하나 COUNT 집계 필요
+     *   현재 구현에서는 제외, 필요 시 서브쿼리 추가
+     * ※ invoice_number: ORDER_PRODUCT 레벨이 아닌 OUTBOUND_PACKING 레벨에 존재
+     *   상세 제품별 송장번호 표시 필요 시 OUTBOUND_PACKING 별도 조회 필요
      */
     public List<OutboundProductDTO> findProducts(int outboundId);
 
     /**
-     * [findAllManifest]
-     * 매니페스트 뷰 목록 조회 (OUTBOUND_TRANSPORTATION 기준)
-     * 대상 테이블: OUTBOUND_TRANSPORTATION
-     *   JOIN PARTNER_COMPANY_MASTER carrier ON ot.carrier_company_id = carrier.id
-     *   JOIN TRANSPORTATION_VEHICLE_MASTER ON ot.transportation_vehicle_id = tvm.id
-     *   JOIN COMMON_CODE ON ot.state_code(*)= cc.id   ← state_code 컬럼 ERD 확인 필요
+     * [selectManifestList] → findAllManifest
+     *
+     * OUTBOUND_TRANSPORTATION 기준 매니페스트 목록 (페이지네이션 포함)
+     *
+     * JOIN 경로:
+     *   OUTBOUND_TRANSPORTATION ot
+     *     → PARTNER_COMPANY_MASTER carrier ON ot.carrier_company_id = carrier.id
+     *     → TRANSPORTATION_VEHICLE_MASTER  tvm ON ot.transportation_vehicle_id = tvm.id
+     *     → OUTBOUND_PACKING op             ON op.outbound_transportation_id = ot.id (LEFT JOIN)
+     *       → OUTBOUND ob                  ON op.outbound_id = ob.id (LEFT JOIN)
+     *         → PARTNER_COMPANY_MASTER pcm ON ob.partner_company_id = pcm.id (필터용, LEFT JOIN)
+     *     → COMMON_CODE cc                  ON ot.state_code = cc.id
+     *
+     * GROUP BY: ot.id (OUTBOUND_PACKING COUNT 집계)
      *
      * 반환 컬럼:
-     *   manifestNo(*), carrierName, vehicleInfo(차량번호 + 종류 조합),
-     *   boxCount(COUNT(OUTBOUND) 집계), stateName, expectedDepartureAt(*), deadline
+     *   transportationId(ot.id), carrierName(carrier.name),
+     *   vehicleInfo(CONCAT(ot.lpn, ' (', tvm.vehicle_type, ')')),
+     *   boxCount(COUNT(op.id)), stateCode(ot.state_code), stateName(cc.name),
+     *   etd(ot.etd), atd(ot.atd), driver(ot.driver)
      *
-     * ※ manifestNo 채번 방식 및 컬럼 ERD 확인 필요
-     * ※ OUTBOUND_TRANSPORTATION에 state_code 컬럼 존재 여부 ERD 확인 필요
-     * ※ 동적 조건: orderStart/orderEnd 적용 범위 확인 필요
-     * ※ 페이지네이션: LIMIT #{offset}, #{size}
+     * ※ manifestNo: OUTBOUND_TRANSPORTATION.id 를 LPAD 포맷으로 가공
+     *   (예: CONCAT('MNF-', LPAD(ot.id, 6, '0')) → 별도 컬럼 없음)
+     * ※ 동적 조건: stateCode(ot.state_code), customerName(pcm.name LIKE, HAVING 또는 WHERE)
+     *              orderStart/orderEnd(ob.order_date 기준, LEFT JOIN 후 WHERE)
+     * ※ ORDER BY ot.id DESC, LIMIT #{offset}, #{size}
+     *
+     * [화면-DB 불일치 주의]
+     * - JSX의 due 필드 = ot.etd 기준으로 프론트가 계산
+     * - JSX 체크박스 활성 조건: status === '차량배정'
+     *   → COMMON_CODE에서 '차량배정' state_code 값 확인 필요
      */
     public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO);
 
     /**
-     * [findByCarrier]
-     * 운송사 목록 조회 (차량 배정 모달 드롭다운용)
-     * 대상 테이블: PARTNER_COMPANY_MASTER
-     * WHERE carrier_yn_code = 1  ← carrier_yn_code 컬럼 ERD 확인 필요
-     *                              (Inbound의 supplier_yn_code = 1 대칭 구조)
+     * [selectCarrierList] → findByCarrier
      *
-     * 반환 컬럼: id, name
+     * 운송사 목록 조회 (차량 배정 모달 드롭다운)
+     * SELECT id, name FROM PARTNER_COMPANY_MASTER WHERE carrier_yn_code = 1
      */
     public List<OutboundCarrierDTO> findByCarrier();
 
     /**
-     * [findByVehicle]
-     * 차량 목록 조회 (차량 배정 모달 드롭다운용)
-     * 대상 테이블: TRANSPORTATION_VEHICLE_MASTER
+     * [selectVehicleList] → findByVehicle
      *
-     * 반환 컬럼: id, vehicleType, vehicleNumber(*)(*), maxPayloadTon
-     *
-     * ※ vehicleNumber 컬럼명 ERD 확인 필요 (ERD에 vehicle_type, max_payload_ton, max_volume 확인됨)
+     * 차량 목록 조회 (차량 배정 모달 드롭다운)
+     * SELECT id, vehicle_type, max_payload_ton FROM TRANSPORTATION_VEHICLE_MASTER
      */
     public List<OutboundTransportationVehicleDTO> findByVehicle();
 
     /**
-     * [addTransportation]
-     * 차량 배정 - OUTBOUND_TRANSPORTATION INSERT
-     * @Options(useGeneratedKeys = true, keyProperty = "transportationId") 적용 필수
+     * [insertTransportation] → addTransportation
      *
-     * INSERT INTO OUTBOUND_TRANSPORTATION (
-     *   transportation_vehicle_id,
-     *   carrier_company_id,
-     *   bpn(*),          ← 예상 출발 일시 컬럼명 ERD 확인 필요
-     *   driver,
-     *   ...              ← 기사 연락처 컬럼 ERD 확인 필요
-     * ) VALUES (...)
+     * OUTBOUND_TRANSPORTATION INSERT
      *
-     * ※ OutboundVehicleAssignDTO.transportationId 에 PK 자동 주입됨
+     * 저장 컬럼:
+     *   carrier_company_id (carrierId)
+     *   transportation_vehicle_id (vehicleId)
+     *   lpn (차량번호 직접 입력)
+     *   driver (기사명)
+     *   etd (예상 출고 일자)
+     *   state_code = 차량배정 상태 ← COMMON_CODE 확인 후 값 결정 필요
+     *
+     * @Options(useGeneratedKeys = true, keyProperty = "transportationId")
+     * → 생성된 PK를 OutboundVehicleAssignDTO.transportationId 에 자동 주입
      */
     @Options(useGeneratedKeys = true, keyProperty = "transportationId")
     public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
 
     /**
-     * [updateTransportationId]
-     * 차량 배정 - 개별 OUTBOUND에 transportation_id 연결 + state_code 변경
+     * [updatePackingTransportation] → updatePackingTransportation
      *
-     * UPDATE OUTBOUND
-     * SET outbound_transportation_id(*) = #{transportationId},
-     *     state_code = [차량배정완료 코드]    ← COMMON_CODE 확인 필요
-     * WHERE id = #{outboundId}
+     * 차량 배정 - OUTBOUND_PACKING UPDATE
      *
-     * ※ OUTBOUND 테이블에 transportation 연결 FK 컬럼명 ERD 확인 필요
-     * @Param 어노테이션으로 두 파라미터 바인딩
+     * UPDATE OUTBOUND_PACKING
+     * SET outbound_transportation_id = #{transportationId},
+     *     state_code = [차량배정 완료 코드],   ← COMMON_CODE 확인 필요
+     *     updated_at = NOW()
+     * WHERE id = #{packingId}
+     *
+     * @Param 두 파라미터 바인딩
      */
-    public int updateTransportationId(@Param("outboundId") int outboundId,
-                                      @Param("transportationId") int transportationId);
+    public int updatePackingTransportation(@Param("packingId") int packingId,
+                                           @Param("transportationId") int transportationId);
 
     /**
-     * [updateInvoice]
-     * 송장 발급 - OUTBOUND UPDATE
+     * [updateInvoiceNumber] → updateInvoiceNumber
      *
-     * UPDATE OUTBOUND
-     * SET invoice_no(*) = #{invoiceNo},   ← invoice_no 컬럼 ERD 확인 필요
-     *     state_code    = [송장발급완료 코드]  ← COMMON_CODE 확인 필요
-     * WHERE id = #{outboundId}
+     * 송장 발급 - OUTBOUND_PACKING UPDATE
      *
-     * ※ invoiceNo 채번 로직:
-     *   - 옵션 A) SQL 내 DATE_FORMAT + LPAD(COUNT+1) 방식 (동시성 취약)
-     *   - 옵션 B) ServiceImp에서 채번 후 DTO에 담아 전달 (권장)
-     *   → 팀 결정 필요
+     * UPDATE OUTBOUND_PACKING
+     * SET invoice_number = #{invoiceNumber},
+     *     state_code = [송장발급완료 코드],    ← COMMON_CODE 확인 필요
+     *     updated_at = NOW()
+     * WHERE id = #{packingId}
+     *
+     * ※ invoiceNumber는 ServiceImp에서 채번 후 DTO에 담아 전달
+     * ※ packing_invoice_number 와 invoice_number 는 별개
+     *   - packing_invoice_number: 패킹 시 생성 (박스 식별용)
+     *   - invoice_number: 송장 발급 후 저장 (운송장번호)
      */
-    public int updateInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
+    public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO);
 
     /**
-     * [updateStateCode]
-     * 출고 확정 - state_code 단순 UPDATE
+     * [updateShipmentConfirm] → updateTransportationConfirm
      *
-     * UPDATE OUTBOUND
-     * SET state_code = #{stateCode}
-     * WHERE id = #{outboundId}
+     * 출고 확정 - OUTBOUND_TRANSPORTATION UPDATE
      *
-     * @Param 어노테이션으로 두 파라미터 바인딩
+     * UPDATE OUTBOUND_TRANSPORTATION
+     * SET state_code = #{stateCode},
+     *     atd = NOW(),
+     *     updated_at = NOW()
+     * WHERE id = #{transportationId}
+     *
+     * @Param 두 파라미터 바인딩
      */
-    public int updateStateCode(@Param("outboundId") int outboundId,
-                               @Param("stateCode") int stateCode);
+    public int updateTransportationConfirm(@Param("transportationId") int transportationId,
+                                           @Param("stateCode") int stateCode);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
@@ -122,10 +122,10 @@ public interface OutboundMapper {
    * 동적 조건: Inbound findAll 패턴 동일 적용
    * ORDER BY op.id DESC, LIMIT #{offset}, #{size}
    */
-  @Select("<script>" +
+@Select("<script>" +
       """
           SELECT
-            `op`.`id`                              AS `packingId`,
+            `op`.`id`                             AS `packingId`,
             `op`.`packing_invoice_number`          AS `packingInvoiceNumber`,
             `op`.`outbound_id`                     AS `outboundId`,
             `pcm`.`name`                           AS `customerName`,
@@ -158,9 +158,17 @@ public interface OutboundMapper {
       "<if test='customerName != null and customerName != \"\"'>" +
       " AND `pcm`.`name` LIKE CONCAT('%', #{customerName}, '%') " +
       "</if>" +
-      "<if test='stateCode != null and stateCode != 0'>" +
-      " AND `op`.`state_code` = #{stateCode} " +
-      "</if>" +
+      
+      // 💡 선택지가 동적으로 바뀌는 핵심 로직
+      "<choose>" +
+      "  <when test='stateCode != null and stateCode != 0'>" +
+      "    AND `op`.`state_code` = #{stateCode} " +  // 개별 코드(20, 21, 22, 23) 선택 시
+      "  </when>" +
+      "  <otherwise>" +
+      "    AND `op`.`state_code` BETWEEN 20 AND 23 " + // 프론트에서 '전체' 선택 시 (기본값)
+      "  </otherwise>" +
+      "</choose>" +
+      
       "</where>" +
       "ORDER BY `op`.`id` DESC LIMIT #{offset}, #{size}" +
       "</script>")

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dao/OutboundMapper.java
@@ -3,279 +3,91 @@ package cloud.weareithero.api.outbound.dao;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Options;
-import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
 
-import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
-import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
-import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
-import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
-import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 
-/**
- * OutboundMapper
- * SQL은 OutboundMapper.xml 에 작성합니다.
- * namespace: cloud.weareithero.api.outbound.dao.OutboundMapper
- *
- * ──────────────────────────────────────────────────────────────────
- * [최신 DB 3차안 기준 OUTBOUND 테이블 구조 요약]
- *
- * OUTBOUND
- *   id, partner_company_id, order_date, deadline, etd, state_code, updated_at
- *   ※ OUTBOUND가 직접 partner_company_id(고객사) 보유
- *   ※ 이전 설계의 ORDER_PRODUCT_LIST 테이블 없음
- *
- * ORDER_PRODUCT
- *   id, outbound_id, outbound_product_id, quantity, price, total_price
- *   ※ outbound_id → OUTBOUND.id 직접 연결
- *
- * OUTBOUND_PACKING (박스 단위)
- *   id, outbound_id, packing_invoice_number, outbound_product_id,
- *   partner_company_id(운송사FK), invoice_number, outbound_transportation_id,
- *   state_code, updated_at
- *   ※ 박스 뷰의 1행 = OUTBOUND_PACKING 1건
- *   ※ packing_invoice_number: 패킹 송장번호 (박스 식별용)
- *   ※ invoice_number: 운송장번호 (발급 후 저장)
- *   ※ partner_company_id: 운송사 FK (carrier_yn_code=1)
- *   ※ outbound_transportation_id: 차량 배정 후 연결
- *   ※ "백엔드 작업 중 수정 필요 시 요청 바람" 주석 있음 → 구조 변경 가능성
- *
- * OUTBOUND_TRANSPORTATION (매니페스트 단위)
- *   id, carrier_company_id, transportation_vehicle_id, lpn, driver,
- *   etd, atd, state_code, updated_at
- *   ※ 매니페스트 뷰의 1행 = OUTBOUND_TRANSPORTATION 1건
- *   ※ etd: 예상 출고 일자 (차량 배정 시 입력)
- *   ※ atd: 실제 출고 일자 (출고 확정 시 NOW())
- *
- * PARTNER_COMPANY_MASTER
- *   id, name, supplier_yn_code, customer_yn_code, carrier_yn_code
- *   ※ 고객사: customer_yn_code=1, 운송사: carrier_yn_code=1
- * ──────────────────────────────────────────────────────────────────
- */
 @Mapper
 public interface OutboundMapper {
 
-    /**
-     * [selectOutboundSummary] → findSummary
-     *
-     * OUTBOUND 기준 상단 집계 카드 5종
-     *
-     * 집계 항목:
-     *   total         - 전체 OUTBOUND 건수
-     *   expectedToday - 당일 etd 기준 미완료 건 (OUTBOUND.etd = CURDATE())
-     *   confirmedToday- 당일 atd 기준 완료 건 (OUTBOUND_TRANSPORTATION.atd = CURDATE())
-     *                   ※ OUTBOUND 직접 atd 없음 → OUTBOUND_PACKING → OUTBOUND_TRANSPORTATION 경로
-     *                   ※ atd는 OUTBOUND_TRANSPORTATION에만 존재
-     *   nearDeadline  - 기한 임박: OUTBOUND.deadline 기준 DATEDIFF 3일 이내 미완료
-     *                   ※ 기준일수(3일) 팀 정의 후 확정
-     *   overdue       - 기한 초과: OUTBOUND.deadline < CURDATE(), 미완료 건
-     *   unassigned    - 미배정: OUTBOUND_PACKING.outbound_transportation_id IS NULL
-     *
-     * 동적 조건: orderStart/orderEnd(OUTBOUND.order_date), outboundId(OUTBOUND.id LIKE),
-     *           customerName(PARTNER_COMPANY_MASTER.name LIKE), stateCode(OUTBOUND.state_code)
-     */
-    public OutboundSummaryDTO findSummary(OutboundRequestDTO outboundRequestDTO);
+    @Select("<script>" +
+        """
+        SELECT
+            `o`.`atd` AS atd,
+            `o`.`id` AS outboundId,
+            `pcm`.`id` AS partnerId,
+            `pcm`.`name` AS partnerName,
+            `wm`.`id` AS warehouseId,
+            `wm`.`name` AS warehouseName
+        FROM `OUTBOUND` `o`
+        JOIN `PARTNER_COMPANY_MASTER` `pcm`
+            ON(`o`.`partner_company_id` = `pcm`.`id`)
+        JOIN `WAREHOUSE_MASTER` `wm`
+            ON(`o`.`warehouse_id` = `wm`.`id`)
+        JOIN `COMMON_CODE` `cc`
+            ON(`o`.`state_code` = `cc`.`id`)
+        """ +
+        "<where>" +
+        " AND `cc`.`name` = '출고완료' " +
+        "<if test='orderStart != null and orderStart != \"\" and orderEnd != null and orderEnd != \"\"'>" +
+        " AND `o`.`atd` BETWEEN STR_TO_DATE(#{orderStart}, '%Y-%m-%d') AND STR_TO_DATE(#{orderEnd}, '%Y-%m-%d') " +
+        "</if>" +
+        "<if test='outboundId != null and outboundId != 0'>" +
+        " AND `o`.`id` LIKE CONCAT('%', #{outboundId}, '%') " +
+        "</if>" +
+        "</where> " +
+        "ORDER BY `o`.`id` DESC LIMIT #{offset}, #{size} " +
+        "</script>")
+    public List<OutboundDTO> findAll(OutboundRequestDTO outboundRequestDTO);
 
-    /**
-     * [selectOutboundList] → findAll
-     *
-     * OUTBOUND_PACKING 박스 목록 (페이지네이션 포함)
-     *
-     * JOIN 경로:
-     *   OUTBOUND_PACKING op
-     *     → OUTBOUND ob               ON op.outbound_id = ob.id
-     *       → PARTNER_COMPANY_MASTER pcm  ON ob.partner_company_id = pcm.id (고객사)
-     *     → PARTNER_COMPANY_MASTER carrier ON op.partner_company_id = carrier.id (운송사, LEFT JOIN)
-     *       ※ op.partner_company_id = 운송사 FK (DB 설계 확인됨)
-     *     → OUTBOUND_TRANSPORTATION ot  ON op.outbound_transportation_id = ot.id (LEFT JOIN)
-     *     → COMMON_CODE cc              ON op.state_code = cc.id
-     *
-     * 반환 컬럼:
-     *   packingId(op.id), packingInvoiceNumber(packing_invoice_number),
-     *   outboundId(ob.id), customerName(pcm.name), carrierName(carrier.name),
-     *   invoiceNumber(op.invoice_number), stateCode(op.state_code), stateName(cc.name),
-     *   deadline(ob.deadline), etd(ob.etd), transportationId(op.outbound_transportation_id)
-     *
-     * ※ 동적 조건: outboundId(ob.id LIKE), customerName(pcm.name LIKE),
-     *              orderStart/orderEnd(ob.order_date), stateCode(op.state_code)
-     * ※ ORDER BY op.id DESC, LIMIT #{offset}, #{size}
-     *
-     * [화면-DB 불일치 주의]
-     * - JSX의 boxNo 필드 = op.packing_invoice_number 로 매핑
-     * - JSX의 orderNo 필드 = ob.id (OUTBOUND.id) 로 매핑
-     *   ('PO-YYYYMMDD-' 형식 표현이 필요하면 CONCAT 가공 또는 프론트 처리)
-     * - JSX의 due 필드 = ob.deadline 기준으로 프론트가 계산 (백엔드는 날짜 반환)
-     */
-    public List<OutboundPackingDTO> findAll(OutboundRequestDTO outboundRequestDTO);
+    @Select("<script>" +
+        "SELECT COUNT(*) FROM `OUTBOUND` `o` " +
+        "JOIN `COMMON_CODE` `cc` ON `o`.`state_code` = `cc`.`id` " +
+        "WHERE `cc`.`name` = '출고완료' " +
+        "<if test='orderStart != null and orderStart != \"\" and orderEnd != null and orderEnd != \"\"'>" +
+        " AND `o`.`atd` BETWEEN STR_TO_DATE(#{orderStart}, '%Y-%m-%d')" +
+        " AND STR_TO_DATE(CONCAT(#{orderEnd}, ' 23:59:59'), '%Y-%m-%d %H:%i:%s') " +
+        "</if>" +
+        "<if test='outboundId != null and outboundId != 0'>" +
+        " AND `o`.`id` = #{outboundId} " +
+        "</if>" +
+        "</script>")
+    int countAll(OutboundRequestDTO outboundRequestDTO);
 
-    /**
-     * [selectOutboundDetail] → findByOutboundId
-     *
-     * OUTBOUND 단건 조회 (상세 모달 헤더용)
-     *
-     * JOIN 경로:
-     *   OUTBOUND ob
-     *     → PARTNER_COMPANY_MASTER pcm ON ob.partner_company_id = pcm.id
-     *     → COMMON_CODE cc             ON ob.state_code = cc.id
-     *
-     * WHERE ob.id = #{outboundId}
-     */
-    public OutboundDTO findByOutboundId(int outboundId);
+    @Select("""
+        SELECT
+            op.`id` AS `no`,
+            op.`outbound_id` AS `outboundId`,
+            op.`material_id` AS `itemNo`,
+            mm.`name` AS `itemName`,
+            mm.`alloy_type` AS `alloyType`,
+            op.`weight_kg` AS `weight`
+        FROM `highgooh`.`ORDER_PRODUCT` AS op
+        INNER JOIN `highgooh`.`MATERIAL_MASTER` AS mm
+        ON (op.`material_id` = mm.`id`)
+        WHERE op.`outbound_id` = #{outboundId}
+            """)
+    public List<OutboundProductDTO> findOne(int outboundId);
 
-    /**
-     * [selectPackingDetail] → findByPackingId
-     *
-     * OUTBOUND_PACKING 단건 조회 (issueInvoice 상태 가드용)
-     * WHERE id = #{packingId}
-     */
-    public OutboundPackingDTO findByPackingId(int packingId);
-
-    /**
-     * [selectOrderProducts] → findProducts
-     *
-     * ORDER_PRODUCT 목록 조회 (상세 모달 제품 목록)
-     *
-     * JOIN 경로:
-     *   ORDER_PRODUCT op
-     *     → OUTBOUND_PRODUCT_MASTER opm ON op.outbound_product_id = opm.id
-     *
-     * WHERE op.outbound_id = #{outboundId}
-     *
-     * 반환 컬럼:
-     *   productId(op.id), productName(opm.name),
-     *   quantity(op.quantity), price(op.price), totalPrice(op.total_price)
-     *
-     * ※ DB 설계상 ORDER_PRODUCT에 box_id 없음 → boxQty 산출 불가
-     *   OUTBOUND_PACKING.outbound_product_id 로 연결은 가능하나 COUNT 집계 필요
-     *   현재 구현에서는 제외, 필요 시 서브쿼리 추가
-     * ※ invoice_number: ORDER_PRODUCT 레벨이 아닌 OUTBOUND_PACKING 레벨에 존재
-     *   상세 제품별 송장번호 표시 필요 시 OUTBOUND_PACKING 별도 조회 필요
-     */
-    public List<OutboundProductDTO> findProducts(int outboundId);
-
-    /**
-     * [selectManifestList] → findAllManifest
-     *
-     * OUTBOUND_TRANSPORTATION 기준 매니페스트 목록 (페이지네이션 포함)
-     *
-     * JOIN 경로:
-     *   OUTBOUND_TRANSPORTATION ot
-     *     → PARTNER_COMPANY_MASTER carrier ON ot.carrier_company_id = carrier.id
-     *     → TRANSPORTATION_VEHICLE_MASTER  tvm ON ot.transportation_vehicle_id = tvm.id
-     *     → OUTBOUND_PACKING op             ON op.outbound_transportation_id = ot.id (LEFT JOIN)
-     *       → OUTBOUND ob                  ON op.outbound_id = ob.id (LEFT JOIN)
-     *         → PARTNER_COMPANY_MASTER pcm ON ob.partner_company_id = pcm.id (필터용, LEFT JOIN)
-     *     → COMMON_CODE cc                  ON ot.state_code = cc.id
-     *
-     * GROUP BY: ot.id (OUTBOUND_PACKING COUNT 집계)
-     *
-     * 반환 컬럼:
-     *   transportationId(ot.id), carrierName(carrier.name),
-     *   vehicleInfo(CONCAT(ot.lpn, ' (', tvm.vehicle_type, ')')),
-     *   boxCount(COUNT(op.id)), stateCode(ot.state_code), stateName(cc.name),
-     *   etd(ot.etd), atd(ot.atd), driver(ot.driver)
-     *
-     * ※ manifestNo: OUTBOUND_TRANSPORTATION.id 를 LPAD 포맷으로 가공
-     *   (예: CONCAT('MNF-', LPAD(ot.id, 6, '0')) → 별도 컬럼 없음)
-     * ※ 동적 조건: stateCode(ot.state_code), customerName(pcm.name LIKE, HAVING 또는 WHERE)
-     *              orderStart/orderEnd(ob.order_date 기준, LEFT JOIN 후 WHERE)
-     * ※ ORDER BY ot.id DESC, LIMIT #{offset}, #{size}
-     *
-     * [화면-DB 불일치 주의]
-     * - JSX의 due 필드 = ot.etd 기준으로 프론트가 계산
-     * - JSX 체크박스 활성 조건: status === '차량배정'
-     *   → COMMON_CODE에서 '차량배정' state_code 값 확인 필요
-     */
-    public List<OutboundManifestDTO> findAllManifest(OutboundRequestDTO outboundRequestDTO);
-
-    /**
-     * [selectCarrierList] → findByCarrier
-     *
-     * 운송사 목록 조회 (차량 배정 모달 드롭다운)
-     * SELECT id, name FROM PARTNER_COMPANY_MASTER WHERE carrier_yn_code = 1
-     */
-    public List<OutboundCarrierDTO> findByCarrier();
-
-    /**
-     * [selectVehicleList] → findByVehicle
-     *
-     * 차량 목록 조회 (차량 배정 모달 드롭다운)
-     * SELECT id, vehicle_type, max_payload_ton FROM TRANSPORTATION_VEHICLE_MASTER
-     */
-    public List<OutboundTransportationVehicleDTO> findByVehicle();
-
-    /**
-     * [insertTransportation] → addTransportation
-     *
-     * OUTBOUND_TRANSPORTATION INSERT
-     *
-     * 저장 컬럼:
-     *   carrier_company_id (carrierId)
-     *   transportation_vehicle_id (vehicleId)
-     *   lpn (차량번호 직접 입력)
-     *   driver (기사명)
-     *   etd (예상 출고 일자)
-     *   state_code = 차량배정 상태 ← COMMON_CODE 확인 후 값 결정 필요
-     *
-     * @Options(useGeneratedKeys = true, keyProperty = "transportationId")
-     * → 생성된 PK를 OutboundVehicleAssignDTO.transportationId 에 자동 주입
-     */
-    @Options(useGeneratedKeys = true, keyProperty = "transportationId")
-    public int addTransportation(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
-
-    /**
-     * [updatePackingTransportation] → updatePackingTransportation
-     *
-     * 차량 배정 - OUTBOUND_PACKING UPDATE
-     *
-     * UPDATE OUTBOUND_PACKING
-     * SET outbound_transportation_id = #{transportationId},
-     *     state_code = [차량배정 완료 코드],   ← COMMON_CODE 확인 필요
-     *     updated_at = NOW()
-     * WHERE id = #{packingId}
-     *
-     * @Param 두 파라미터 바인딩
-     */
-    public int updatePackingTransportation(@Param("packingId") int packingId,
-                                           @Param("transportationId") int transportationId);
-
-    /**
-     * [updateInvoiceNumber] → updateInvoiceNumber
-     *
-     * 송장 발급 - OUTBOUND_PACKING UPDATE
-     *
-     * UPDATE OUTBOUND_PACKING
-     * SET invoice_number = #{invoiceNumber},
-     *     state_code = [송장발급완료 코드],    ← COMMON_CODE 확인 필요
-     *     updated_at = NOW()
-     * WHERE id = #{packingId}
-     *
-     * ※ invoiceNumber는 ServiceImp에서 채번 후 DTO에 담아 전달
-     * ※ packing_invoice_number 와 invoice_number 는 별개
-     *   - packing_invoice_number: 패킹 시 생성 (박스 식별용)
-     *   - invoice_number: 송장 발급 후 저장 (운송장번호)
-     */
-    public int updateInvoiceNumber(OutboundInvoiceDTO outboundInvoiceDTO);
-
-    /**
-     * [updateShipmentConfirm] → updateTransportationConfirm
-     *
-     * 출고 확정 - OUTBOUND_TRANSPORTATION UPDATE
-     *
-     * UPDATE OUTBOUND_TRANSPORTATION
-     * SET state_code = #{stateCode},
-     *     atd = NOW(),
-     *     updated_at = NOW()
-     * WHERE id = #{transportationId}
-     *
-     * @Param 두 파라미터 바인딩
-     */
-    public int updateTransportationConfirm(@Param("transportationId") int transportationId,
-                                           @Param("stateCode") int stateCode);
+    @Select("""
+        SELECT
+            `o`.`atd` AS atd,
+            `o`.`id` AS outboundId,
+            `pcm`.`id` AS partnerId,
+            `pcm`.`name` AS partnerName,
+            `wm`.`id` AS warehouseId,
+            `wm`.`name` AS warehouseName
+        FROM `OUTBOUND` `o`
+        JOIN `PARTNER_COMPANY_MASTER` `pcm`
+            ON(`o`.`partner_company_id` = `pcm`.`id`)
+        JOIN `WAREHOUSE_MASTER` `wm`
+            ON(`o`.`warehouse_id` = `wm`.`id`)
+        JOIN `COMMON_CODE` `cc`
+            ON(`o`.`state_code` = `cc`.`id`)
+        WHERE `o`.`id` = #{outboundId}
+        """)
+    public OutboundDTO findbyOutboundId(int outboundId);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundCarrierDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundCarrierDTO.java
@@ -6,7 +6,8 @@ import lombok.NoArgsConstructor;
 
 /**
  * 운송사 목록 DTO (차량 배정 모달 드롭다운)
- * PARTNER_COMPANY_MASTER.carrier_yn_code = 1 인 운송사만 조회
+ * PARTNER_COMPANY_MASTER WHERE carrier_yn_code = 1
+ * Inbound의 AsnSupplierDTO(supplier_yn_code=1) 대칭 구조
  */
 @Data
 @AllArgsConstructor

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundCarrierDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundCarrierDTO.java
@@ -1,0 +1,19 @@
+package cloud.weareithero.api.outbound.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 운송사 목록 DTO (차량 배정 모달 드롭다운)
+ * PARTNER_COMPANY_MASTER.carrier_yn_code = 1 인 운송사만 조회
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutboundCarrierDTO {
+
+    private int id;
+    private String name;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundConfirmDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundConfirmDTO.java
@@ -9,13 +9,22 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * 출고 확정 요청 DTO
+ *
+ * 매니페스트 탭에서 체크박스로 선택한 OUTBOUND_TRANSPORTATION.id 목록을 받아
+ * state_code → 출고완료, atd = NOW() UPDATE
+ *
+ * ※ 매니페스트 단위 확정 (박스 단위 아님)
+ * ※ JSX 매니페스트 탭 [출고 확정] 버튼 → checkedManifests → transportationIds 로 전달
+ */
 @Setter @Getter @ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Schema(description = "출고 확정 요청 DTO")
 public class OutboundConfirmDTO {
 
-    @Schema(description = "출고 확정 대상 OUTBOUND ID 목록")
-    private List<Integer> outboundIds;
+    @Schema(description = "확정 대상 OUTBOUND_TRANSPORTATION.id 목록 (매니페스트 ID)")
+    private List<Integer> transportationIds;
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundConfirmDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundConfirmDTO.java
@@ -1,0 +1,21 @@
+package cloud.weareithero.api.outbound.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter @Getter @ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "출고 확정 요청 DTO")
+public class OutboundConfirmDTO {
+
+    @Schema(description = "출고 확정 대상 OUTBOUND ID 목록")
+    private List<Integer> outboundIds;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundDTO.java
@@ -1,0 +1,30 @@
+package cloud.weareithero.api.outbound.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutboundDTO {
+
+    private int outboundId;           // OUTBOUND.id
+    private String orderNo;           // OUTBOUND.id가 주문번호의 역할을 해서 outboundId 둘 중 하나만 있어도 되지 않나?
+    private String customerName;      // PARTNER_COMPANY_MASTER.name (고객사명)
+    private String carrierName;       // 운송사명 (PARTNER_COMPANY_MASTER.carrier_yn_code)
+
+    private String invoiceNo;         // 송장번호 (invoice_no 컬럼 존재)
+    private LocalDateTime etd;        // 기한 / 예상 출고 일시 (OUTBOUND.etd)
+
+    private int stateCode;            // OUTBOUND.state_code (COMMON_CODE 테이블에서 id 가져옴)
+    private String stateName;         // COMMON_CODE.name (출고대기 / 출고처리중 / 출고완료 / 부분출고 총 4개 존재함)
+
+    // 매니페스트 뷰 연결용 (차량 배정 후 설정)
+    private Integer transportationId;     // OUTBOUND_TRANSPORTATION.id (FK: transportation_vehicle_id 컬럼 존재)
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundDTO.java
@@ -1,30 +1,35 @@
 package cloud.weareithero.api.outbound.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * OUTBOUND 단건 조회 DTO (상세 모달 헤더용)
+ *
+ * 기준 테이블: OUTBOUND
+ *   id, partner_company_id, order_date, deadline, etd, state_code, updated_at
+ *
+ * JOIN:
+ *   PARTNER_COMPANY_MASTER (고객사명)
+ *   COMMON_CODE (상태명)
+ */
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class OutboundDTO {
 
-    private int outboundId;           // OUTBOUND.id
-    private String orderNo;           // OUTBOUND.id가 주문번호의 역할을 해서 outboundId 둘 중 하나만 있어도 되지 않나?
-    private String customerName;      // PARTNER_COMPANY_MASTER.name (고객사명)
-    private String carrierName;       // 운송사명 (PARTNER_COMPANY_MASTER.carrier_yn_code)
-
-    private String invoiceNo;         // 송장번호 (invoice_no 컬럼 존재)
-    private LocalDateTime etd;        // 기한 / 예상 출고 일시 (OUTBOUND.etd)
-
-    private int stateCode;            // OUTBOUND.state_code (COMMON_CODE 테이블에서 id 가져옴)
-    private String stateName;         // COMMON_CODE.name (출고대기 / 출고처리중 / 출고완료 / 부분출고 총 4개 존재함)
-
-    // 매니페스트 뷰 연결용 (차량 배정 후 설정)
-    private Integer transportationId;     // OUTBOUND_TRANSPORTATION.id (FK: transportation_vehicle_id 컬럼 존재)
+    private int outboundId;         // OUTBOUND.id
+    private int partnerId;          // OUTBOUND.partner_company_id
+    private String partnerName;     // PARTNER_COMPANY_MASTER.name (고객사)
+    private LocalDate orderDate;    // OUTBOUND.order_date
+    private LocalDate deadline;     // OUTBOUND.deadline (주문 마감일)
+    private LocalDate etd;          // OUTBOUND.etd (출발 예정일)
+    private int stateCode;          // OUTBOUND.state_code
+    private String stateName;       // COMMON_CODE.name
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundDetailDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundDetailDTO.java
@@ -1,5 +1,0 @@
-package cloud.weareithero.api.outbound.dto;
-
-public class OutboundDetailDTO {
-    
-}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundDetailDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundDetailDTO.java
@@ -1,0 +1,5 @@
+package cloud.weareithero.api.outbound.dto;
+
+public class OutboundDetailDTO {
+    
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundInvoiceDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundInvoiceDTO.java
@@ -45,4 +45,5 @@ public class OutboundInvoiceDTO {
     //   옵션 B) 별도 시퀀스 테이블
     //   옵션 C) UUID
 
+    private int stateCode;
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundInvoiceDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundInvoiceDTO.java
@@ -9,15 +9,40 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-@Setter
-@Getter
-@ToString
+/**
+ * 송장 발급 요청 DTO
+ *
+ * OUTBOUND_PACKING.invoice_number 에 운송장번호를 저장하고
+ * state_code를 변경하는 UPDATE 요청
+ *
+ * ※ packingIds: 복수 박스 일괄 발급 지원
+ *   (JSX 송장 모달의 activeInvoiceBoxes 목록 기준)
+ * ※ invoiceNumber: ServiceImp에서 채번 후 Mapper 호출 시 설정
+ *   → 현재 단일 invoiceNumber를 루프 내 개별 재설정하는 구조
+ *   → 박스별 고유 번호가 필요한 경우 추가 로직 필요
+ *
+ * [DB 컬럼 설명]
+ * OUTBOUND_PACKING.invoice_number    = 운송장번호 (발급 후 저장)
+ * OUTBOUND_PACKING.packing_invoice_number = 패킹 송장번호 (박스 식별, 기존 값 유지)
+ */
+@Setter @Getter @ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Schema(description = "송장 발급 요청 DTO")
 public class OutboundInvoiceDTO {
 
-    @Schema(description = "송장 발급 대상 출고 ID 목록")
-    private List<Integer> outboundIds;
+    @Schema(description = "송장 발급 대상 OUTBOUND_PACKING.id 목록")
+    private List<Integer> packingIds;
+
+    // ServiceImp 루프 내에서 개별 packingId 설정용 (단건 UPDATE 시 사용)
+    private int packingId;
+
+    @Schema(description = "운송장번호 (OUTBOUND_PACKING.invoice_number, 채번 후 저장)")
+    private String invoiceNumber;
+
+    // TODO: 송장번호 채번 방식 팀 결정 필요
+    //   옵션 A) 날짜 + OUTBOUND_PACKING.id 조합 (INV-YYYYMMDD-{packingId})
+    //   옵션 B) 별도 시퀀스 테이블
+    //   옵션 C) UUID
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundInvoiceDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundInvoiceDTO.java
@@ -38,12 +38,10 @@ public class OutboundInvoiceDTO {
     private int packingId;
 
     @Schema(description = "운송장번호 (OUTBOUND_PACKING.invoice_number, 채번 후 저장)")
-    private String invoiceNumber;
+    private String invoiceNumber; 
 
     // TODO: 송장번호 채번 방식 팀 결정 필요
     //   옵션 A) 날짜 + OUTBOUND_PACKING.id 조합 (INV-YYYYMMDD-{packingId})
-    //   옵션 B) 별도 시퀀스 테이블
-    //   옵션 C) UUID
 
     private int stateCode;
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundInvoiceDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundInvoiceDTO.java
@@ -1,0 +1,23 @@
+package cloud.weareithero.api.outbound.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "송장 발급 요청 DTO")
+public class OutboundInvoiceDTO {
+
+    @Schema(description = "송장 발급 대상 출고 ID 목록")
+    private List<Integer> outboundIds;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundManifestDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundManifestDTO.java
@@ -1,0 +1,33 @@
+package cloud.weareithero.api.outbound.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 매니페스트 뷰 목록 1행
+ * 대상 테이블: OUTBOUND_TRANSPORTATION 기준 집계
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutboundManifestDTO {
+
+    private int transportationId;         // OUTBOUND_TRANSPORTATION.id
+
+    // ※ 매니페스트 번호 채번 방식 DB에서 끌고 오는걸로 (단순 숫자)
+    private String manifestNo;            // 매니페스트 번호
+
+    private String carrierName;           // 운송사명
+    private String vehicleInfo;           // 차량번호 + 종류 조합 문자열 (예: "11가 1234 (1톤 탑차)")
+    private int boxCount;                 // 적재 박스 수 (COUNT 집계)
+
+    private int stateCode;                // OUTBOUND_TRANSPORTATION.state_code 컬럼 없어서 추가함 // 수정
+    private String stateName;             // COMMON_CODE에 outbound 부분 추가
+
+    private LocalDateTime expectedDepartureAt; // OUTBOUND.etd 출발 예정 일자 (시간 단위로 관리 안하고 날짜 단위로 관리)
+    private LocalDateTime deadline;            // OUTBOUND.deadline 에서 가져오기
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundManifestDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundManifestDTO.java
@@ -8,26 +8,44 @@ import lombok.NoArgsConstructor;
 
 /**
  * 매니페스트 뷰 목록 1행
- * 대상 테이블: OUTBOUND_TRANSPORTATION 기준 집계
+ *
+ * 기준 테이블: OUTBOUND_TRANSPORTATION (3차안 기준)
+ *   id, carrier_company_id, transportation_vehicle_id, lpn, driver,
+ *   etd, atd, state_code, updated_at
+ *
+ * JOIN:
+ *   PARTNER_COMPANY_MASTER carrier (carrier_company_id)
+ *   TRANSPORTATION_VEHICLE_MASTER tvm (transportation_vehicle_id)
+ *   OUTBOUND_PACKING op → COUNT (박스 수 집계)
+ *   COMMON_CODE cc (OUTBOUND_TRANSPORTATION.state_code)
+ *
+ * ──────────────────────────────────────────────
+ * JSX 매니페스트 테이블 컬럼 → DB 필드 매핑
+ * ──────────────────────────────────────────────
+ * mnfNo   → CONCAT('MNF-', LPAD(ot.id, 6, '0')) 가공 (별도 컬럼 없음)
+ * carrier → PARTNER_COMPANY_MASTER.name
+ * vehicle → CONCAT(ot.lpn, ' (', tvm.vehicle_type, ')')
+ * boxes   → COUNT(op.id) || ' BOX'
+ * status  → COMMON_CODE.name
+ * due     → ot.etd (프론트에서 NOW()와 비교)
+ *
+ * ※ JSX 체크박스 활성 조건: status === '차량배정'
+ *   → COMMON_CODE에서 '차량배정' state_code 정수값 확인 필요
  */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class OutboundManifestDTO {
 
-    private int transportationId;         // OUTBOUND_TRANSPORTATION.id
-
-    // ※ 매니페스트 번호 채번 방식 DB에서 끌고 오는걸로 (단순 숫자)
-    private String manifestNo;            // 매니페스트 번호
-
-    private String carrierName;           // 운송사명
-    private String vehicleInfo;           // 차량번호 + 종류 조합 문자열 (예: "11가 1234 (1톤 탑차)")
-    private int boxCount;                 // 적재 박스 수 (COUNT 집계)
-
-    private int stateCode;                // OUTBOUND_TRANSPORTATION.state_code 컬럼 없어서 추가함 // 수정
-    private String stateName;             // COMMON_CODE에 outbound 부분 추가
-
-    private LocalDateTime expectedDepartureAt; // OUTBOUND.etd 출발 예정 일자 (시간 단위로 관리 안하고 날짜 단위로 관리)
-    private LocalDateTime deadline;            // OUTBOUND.deadline 에서 가져오기
+    private int transportationId;       // OUTBOUND_TRANSPORTATION.id
+    private String manifestNo;          // CONCAT 가공 (MNF-000001 형식)
+    private String carrierName;         // 운송사명
+    private String vehicleInfo;         // 차량번호 + 종류 (lpn + vehicle_type)
+    private int boxCount;               // 연결된 OUTBOUND_PACKING COUNT
+    private int stateCode;              // OUTBOUND_TRANSPORTATION.state_code
+    private String stateName;           // COMMON_CODE.name
+    private LocalDateTime etd;          // OUTBOUND_TRANSPORTATION.etd (예상 출고일)
+    private LocalDateTime atd;          // OUTBOUND_TRANSPORTATION.atd (실제 출고일)
+    private String driver;              // OUTBOUND_TRANSPORTATION.driver
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundPackingDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundPackingDTO.java
@@ -1,0 +1,59 @@
+package cloud.weareithero.api.outbound.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 박스 뷰 목록 1행 DTO
+ *
+ * 기준 테이블: OUTBOUND_PACKING
+ *   id, outbound_id, packing_invoice_number, outbound_product_id,
+ *   partner_company_id(운송사), invoice_number, outbound_transportation_id,
+ *   state_code, updated_at
+ *
+ * JOIN:
+ *   OUTBOUND (outbound_id)
+ *   PARTNER_COMPANY_MASTER pcm (OUTBOUND.partner_company_id - 고객사)
+ *   PARTNER_COMPANY_MASTER carrier (OUTBOUND_PACKING.partner_company_id - 운송사, LEFT JOIN)
+ *   OUTBOUND_TRANSPORTATION (outbound_transportation_id, LEFT JOIN)
+ *   COMMON_CODE (OUTBOUND_PACKING.state_code)
+ *
+ * ──────────────────────────────────
+ * JSX 박스 테이블 컬럼 → DB 필드 매핑
+ * ──────────────────────────────────
+ * boxNo       → packing_invoice_number  (패킹 송장번호, 박스 식별자)
+ * orderNo     → outbound_id (OUTBOUND.id)
+ *               ※ 'PO-YYYYMMDD-' 형식은 DB에 없음 → 프론트 가공 또는 팀 협의 필요
+ * customer    → PARTNER_COMPANY_MASTER.name (고객사)
+ * carrier     → PARTNER_COMPANY_MASTER.name (운송사, carrier_yn_code=1)
+ * status      → COMMON_CODE.name (OUTBOUND_PACKING.state_code 기준)
+ * invNo       → invoice_number (운송장번호, 송장 발급 후 저장)
+ * due         → OUTBOUND.deadline (프론트에서 NOW()와 비교하여 '17분 남음' 등 표시)
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutboundPackingDTO {
+
+    private int packingId;                  // OUTBOUND_PACKING.id
+    private String packingInvoiceNumber;    // OUTBOUND_PACKING.packing_invoice_number (박스번호)
+    private int outboundId;                 // OUTBOUND_PACKING.outbound_id (주문번호)
+    private String customerName;            // 고객사명 (OUTBOUND → PARTNER_COMPANY_MASTER)
+    private String carrierName;             // 운송사명 (OUTBOUND_PACKING.partner_company_id → PARTNER_COMPANY_MASTER)
+    private String invoiceNumber;           // OUTBOUND_PACKING.invoice_number (운송장번호, 발급 전 null)
+    private int stateCode;                  // OUTBOUND_PACKING.state_code
+    private String stateName;               // COMMON_CODE.name
+    private LocalDate deadline;             // OUTBOUND.deadline (기한, 프론트 계산 기준)
+    private LocalDate etd;                  // OUTBOUND.etd (출발 예정일)
+    private Integer transportationId;       // OUTBOUND_PACKING.outbound_transportation_id (null=미배정)
+
+    // ※ selectable(체크박스 활성 여부): transportationId IS NULL 이면 true
+    //    프론트에서 이 필드 기반으로 체크박스 disabled 처리 가능
+    //    또는 별도 boolean 필드 추가 가능
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundProductDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundProductDTO.java
@@ -7,7 +7,15 @@ import lombok.NoArgsConstructor;
 
 /**
  * 주문 상세 모달 제품 목록 1행
- * 대상 테이블: ORDER_PRODUCT JOIN OUTBOUND_PRODUCT_MASTER JOIN PRODUCT_PRICE
+ *
+ * 기준 테이블: ORDER_PRODUCT (3차안 기준)
+ *   id, outbound_id, outbound_product_id, quantity, price, total_price
+ *
+ * JOIN: OUTBOUND_PRODUCT_MASTER (제품명)
+ *
+ * ※ DB에 ORDER_PRODUCT.box_id 없음 → boxQty 산출 불가 (JSX dummyOrderDetails의 boxQty 화면 표시 불일치)
+ * ※ invoice_number는 ORDER_PRODUCT 레벨이 아닌 OUTBOUND_PACKING 레벨에 존재
+ *    (JSX dummyOrderDetails의 invoiceNo는 DB와 레벨 불일치 - 팀 협의 필요)
  */
 @Data
 @Builder
@@ -15,12 +23,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class OutboundProductDTO {
 
-    private int productId;       // OUTBOUND_PRODUCT_MASTER.id
-    private String productName;  // OUTBOUND_PRODUCT_MASTER.name
-    private int quantity;        // ORDER_PRODUCT.quantity
-    private long totalPrice;     // ORDER_PRODUCT.total_price
+    private int productId;          // ORDER_PRODUCT.id
+    private String productName;     // OUTBOUND_PRODUCT_MASTER.name
+    private int quantity;           // ORDER_PRODUCT.quantity (수량, 세트)
+    private long price;             // ORDER_PRODUCT.price (세트당 가격)
+    private long totalPrice;        // ORDER_PRODUCT.total_price (총 가격)
 
-    private int boxQty;          // OUTBOUND_PACKING.total_box_quantity 사용
-    private String invoiceNo;    // OUTBOUND_TRANSPORT.invoice_number 사용
+    // ※ 아래 필드는 DB에 직접 대응 컬럼 없음 → 현재 구현 제외, 필요 시 팀 협의
+    // private int boxQty;          // JSX에 존재하나 ORDER_PRODUCT에 box_id 없음
+    // private String invoiceNo;    // ORDER_PRODUCT 레벨에 없음, OUTBOUND_PACKING에 존재
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundProductDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundProductDTO.java
@@ -1,0 +1,26 @@
+package cloud.weareithero.api.outbound.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 주문 상세 모달 제품 목록 1행
+ * 대상 테이블: ORDER_PRODUCT JOIN OUTBOUND_PRODUCT_MASTER JOIN PRODUCT_PRICE
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutboundProductDTO {
+
+    private int productId;       // OUTBOUND_PRODUCT_MASTER.id
+    private String productName;  // OUTBOUND_PRODUCT_MASTER.name
+    private int quantity;        // ORDER_PRODUCT.quantity
+    private long totalPrice;     // ORDER_PRODUCT.total_price
+
+    private int boxQty;          // OUTBOUND_PACKING.total_box_quantity 사용
+    private String invoiceNo;    // OUTBOUND_TRANSPORT.invoice_number 사용
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundRequestDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundRequestDTO.java
@@ -11,25 +11,22 @@ import lombok.ToString;
 @Setter @Getter @ToString
 @AllArgsConstructor
 @NoArgsConstructor
-@Schema(description = "출고 요청 데이터")
+@Schema(description = "출고 목록 조회 요청 데이터")
 public class OutboundRequestDTO extends PageRequestDTO {
 
-    @Schema(description = "출고 ID", defaultValue = "0", example = "0")
+    @Schema(description = "출고 ID (OUTBOUND.id, 0이면 전체)", defaultValue = "0", example = "0")
     private int outboundId;
 
-    @Schema(description = "주문번호 검색어", defaultValue = "", example = "")
-    private String orderNo;
-
-    @Schema(description = "고객사명 검색어", defaultValue = "", example = "")
+    @Schema(description = "고객사명 검색어 (PARTNER_COMPANY_MASTER.name LIKE)", defaultValue = "", example = "")
     private String customerName;
 
-    @Schema(description = "진행 상태 코드 (0: 전체)", defaultValue = "0", example = "0")
+    @Schema(description = "진행 상태 코드 (OUTBOUND.state_code, 0이면 전체)", defaultValue = "0", example = "0")
     private int stateCode;
 
-    @Schema(description = "주문 시작일", defaultValue = "", example = "")
+    @Schema(description = "주문 시작일 (OUTBOUND.order_date 기준)", defaultValue = "", example = "")
     private String orderStart;
 
-    @Schema(description = "주문 종료일", defaultValue = "", example = "")
+    @Schema(description = "주문 종료일 (OUTBOUND.order_date 기준)", defaultValue = "", example = "")
     private String orderEnd;
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundRequestDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundRequestDTO.java
@@ -1,0 +1,35 @@
+package cloud.weareithero.api.outbound.dto;
+
+import cloud.weareithero.dto.PageRequestDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter @Getter @ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "출고 요청 데이터")
+public class OutboundRequestDTO extends PageRequestDTO {
+
+    @Schema(description = "출고 ID", defaultValue = "0", example = "0")
+    private int outboundId;
+
+    @Schema(description = "주문번호 검색어", defaultValue = "", example = "")
+    private String orderNo;
+
+    @Schema(description = "고객사명 검색어", defaultValue = "", example = "")
+    private String customerName;
+
+    @Schema(description = "진행 상태 코드 (0: 전체)", defaultValue = "0", example = "0")
+    private int stateCode;
+
+    @Schema(description = "주문 시작일", defaultValue = "", example = "")
+    private String orderStart;
+
+    @Schema(description = "주문 종료일", defaultValue = "", example = "")
+    private String orderEnd;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundSummaryDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundSummaryDTO.java
@@ -6,17 +6,29 @@ import lombok.NoArgsConstructor;
 
 /**
  * 출고 화면 상단 집계 카드 5종
+ * Inbound의 AsnSummaryDTO(3종)와 달리 5종 집계
+ *
+ * 집계 기준: OUTBOUND 테이블
+ * ─────────────────────────────────────────
+ * total         - 전체 OUTBOUND 건수 (페이지네이션 totalCount 용도)
+ * expectedToday - 당일 출고 예정 (OUTBOUND.etd = CURDATE(), 미완료)
+ * confirmedToday- 당일 출고 확정 (OUTBOUND_TRANSPORTATION.atd = CURDATE())
+ *                 ※ OUTBOUND에 atd 없음 → OUTBOUND_PACKING → OT 경로 집계 필요
+ * nearDeadline  - 기한 임박 (OUTBOUND.deadline - CURDATE() ≤ 3일, 미완료)
+ *                 ※ 기준일수 팀 협의 필요
+ * overdue       - 기한 초과 (OUTBOUND.deadline < CURDATE(), 미완료)
+ * unassigned    - 미배정 (OUTBOUND_PACKING.outbound_transportation_id IS NULL)
  */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class OutboundSummaryDTO {
 
-    private int total;           // 전체 건수 (페이지네이션 totalCount 용도로도 사용)
-    private int expectedToday;   // 출고 예정 (당일)
-    private int confirmedToday;  // 출고 확정 (당일)
-    private int nearDeadline;    // 기한 임박 (기준: 팀 정의 필요 — etd - NOW() < N분)
-    private int overdue;         // 기한 초과 (etd < NOW(), 미확정 건)
-    private int unassigned;      // 미배정 (차량 미배정 건)
+    private int total;
+    private int expectedToday;
+    private int confirmedToday;
+    private int nearDeadline;
+    private int overdue;
+    private int unassigned;
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundSummaryDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundSummaryDTO.java
@@ -1,0 +1,22 @@
+package cloud.weareithero.api.outbound.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 출고 화면 상단 집계 카드 5종
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutboundSummaryDTO {
+
+    private int total;           // 전체 건수 (페이지네이션 totalCount 용도로도 사용)
+    private int expectedToday;   // 출고 예정 (당일)
+    private int confirmedToday;  // 출고 확정 (당일)
+    private int nearDeadline;    // 기한 임박 (기준: 팀 정의 필요 — etd - NOW() < N분)
+    private int overdue;         // 기한 초과 (etd < NOW(), 미확정 건)
+    private int unassigned;      // 미배정 (차량 미배정 건)
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundTransportationVehicleDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundTransportationVehicleDTO.java
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 
 /**
  * 차량 목록 DTO (차량 배정 모달 드롭다운)
- * Inbound의 AsnWarehouseDTO와 대응하는 구조
- * 대상 테이블: TRANSPORTATION_VEHICLE_MASTER
+ * TRANSPORTATION_VEHICLE_MASTER 전체 조회
  *
- * ERD 확인된 컬럼: id, vehicle_type, max_payload_ton, max_volume
- * ※ vehicle_number 컬럼명 ERD 확인 필요 (화면에서 "서울88바 1234" 형식 표시됨)
+ * DB 확인된 컬럼: id, vehicle_type, max_payload_ton, max_volume
+ * ※ 차량 번호판(lpn)은 OUTBOUND_TRANSPORTATION에 저장, 마스터 테이블에 없음
+ *    차량 배정 모달에서 lpn을 직접 입력받아 OutboundVehicleAssignDTO.lpn 으로 전달
  */
 @Data
 @AllArgsConstructor
@@ -19,7 +19,6 @@ public class OutboundTransportationVehicleDTO {
 
     private int id;
     private String vehicleType;       // TRANSPORTATION_VEHICLE_MASTER.vehicle_type
-    private String vehicleNumber;     // 이게 정확히 뭘 알고 싶은거지? 차 몇 대 있는지?
     private double maxPayloadTon;     // TRANSPORTATION_VEHICLE_MASTER.max_payload_ton
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundTransportationVehicleDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundTransportationVehicleDTO.java
@@ -1,0 +1,25 @@
+package cloud.weareithero.api.outbound.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 차량 목록 DTO (차량 배정 모달 드롭다운)
+ * Inbound의 AsnWarehouseDTO와 대응하는 구조
+ * 대상 테이블: TRANSPORTATION_VEHICLE_MASTER
+ *
+ * ERD 확인된 컬럼: id, vehicle_type, max_payload_ton, max_volume
+ * ※ vehicle_number 컬럼명 ERD 확인 필요 (화면에서 "서울88바 1234" 형식 표시됨)
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutboundTransportationVehicleDTO {
+
+    private int id;
+    private String vehicleType;       // TRANSPORTATION_VEHICLE_MASTER.vehicle_type
+    private String vehicleNumber;     // 이게 정확히 뭘 알고 싶은거지? 차 몇 대 있는지?
+    private double maxPayloadTon;     // TRANSPORTATION_VEHICLE_MASTER.max_payload_ton
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundVehicleAssignDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundVehicleAssignDTO.java
@@ -32,6 +32,9 @@ public class OutboundVehicleAssignDTO {
     @Schema(description = "배정 대상 OUTBOUND_PACKING.id 목록 (체크박스 선택)")
     private List<Integer> packingIds;
 
+    @Schema(description = "변경할 패킹 상태 코드 (COMMON_CODE.id 참조)")
+    private int stateCode;
+   
     @Schema(description = "운송사 ID (PARTNER_COMPANY_MASTER.id, carrier_yn_code=1)")
     private int carrierId;
 

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundVehicleAssignDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundVehicleAssignDTO.java
@@ -1,0 +1,34 @@
+package cloud.weareithero.api.outbound.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter @Getter @ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "차량 배정 요청 DTO")
+public class OutboundVehicleAssignDTO {
+
+    @Schema(description = "배정 대상 출고 ID 목록 (체크박스 선택)")
+    private List<Integer> outboundIds;
+
+    @Schema(description = "운송사 ID (PARTNER_COMPANY_MASTER.id - carrier)")
+    private int carrierId;
+
+    @Schema(description = "차량 ID (TRANSPORTATION_VEHICLE_MASTER.id)")
+    private int vehicleId;
+
+    @Schema(description = "기사명")
+    private String driver;
+
+    // ※ addTransportation() 후 @Options(useGeneratedKeys)로 PK 자동 주입되는 필드
+    // DaoImp.addTransportation() 에서 이 값을 읽어 반환합니다.
+    private int transportationId;
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundVehicleAssignDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/dto/OutboundVehicleAssignDTO.java
@@ -9,26 +9,46 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * 차량 배정 요청 DTO
+ *
+ * 박스 탭에서 체크박스로 선택한 OUTBOUND_PACKING.id 목록을 받아
+ * OUTBOUND_TRANSPORTATION 1건 INSERT 후 각 OUTBOUND_PACKING 에 연결
+ *
+ * ※ JSX 차량 배정 모달 입력 항목:
+ *   - 운송사 (select)
+ *   - 차량 (select)
+ *   - 예상 출발 일시 (datetime-local, 주석처리됨 - 필요 시 활성화)
+ *
+ * ※ 기사명(driver), 차량번호(lpn)는 차량 배정 시 직접 입력
+ *   → OUTBOUND_TRANSPORTATION.driver, lpn 에 저장
+ */
 @Setter @Getter @ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Schema(description = "차량 배정 요청 DTO")
 public class OutboundVehicleAssignDTO {
 
-    @Schema(description = "배정 대상 출고 ID 목록 (체크박스 선택)")
-    private List<Integer> outboundIds;
+    @Schema(description = "배정 대상 OUTBOUND_PACKING.id 목록 (체크박스 선택)")
+    private List<Integer> packingIds;
 
-    @Schema(description = "운송사 ID (PARTNER_COMPANY_MASTER.id - carrier)")
+    @Schema(description = "운송사 ID (PARTNER_COMPANY_MASTER.id, carrier_yn_code=1)")
     private int carrierId;
 
     @Schema(description = "차량 ID (TRANSPORTATION_VEHICLE_MASTER.id)")
     private int vehicleId;
 
-    @Schema(description = "기사명")
+    @Schema(description = "차량 번호판 (OUTBOUND_TRANSPORTATION.lpn)")
+    private String lpn;
+
+    @Schema(description = "기사명 (OUTBOUND_TRANSPORTATION.driver)")
     private String driver;
 
-    // ※ addTransportation() 후 @Options(useGeneratedKeys)로 PK 자동 주입되는 필드
-    // DaoImp.addTransportation() 에서 이 값을 읽어 반환합니다.
+    @Schema(description = "예상 출고 일자 (OUTBOUND_TRANSPORTATION.etd, 'yyyy-MM-dd' 형식)")
+    private String etd;
+
+    // addTransportation() 후 @Options(useGeneratedKeys)로 PK 자동 주입
+    // DaoImp에서 이 값을 읽어 반환
     private int transportationId;
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundService.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundService.java
@@ -1,0 +1,25 @@
+package cloud.weareithero.api.outbound.service;
+
+import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
+import cloud.weareithero.dto.ResponseDTO;
+
+public interface OutboundService {
+
+    public ResponseDTO findAll(OutboundRequestDTO outboundRequestDTO);
+
+    public ResponseDTO findOne(int outboundId);
+
+    public ResponseDTO findAllManifest(OutboundRequestDTO outboundRequestDTO);
+
+    public ResponseDTO findAllOutbound();
+
+    public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
+
+    public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
+
+    public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO);
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundService.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundService.java
@@ -1,32 +1,14 @@
 package cloud.weareithero.api.outbound.service;
 
-import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
-import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 import cloud.weareithero.dto.ResponseDTO;
 
 public interface OutboundService {
 
-    /** 박스 뷰 목록 조회 (OUTBOUND_PACKING 기준) */
+    /** 출고 목록 조회 (필터 + 페이지네이션) */
     public ResponseDTO findAll(OutboundRequestDTO outboundRequestDTO);
 
     /** 주문 상세 조회 (OUTBOUND 헤더 + ORDER_PRODUCT 목록) */
     public ResponseDTO findOne(int outboundId);
-
-    /** 매니페스트 뷰 목록 조회 (OUTBOUND_TRANSPORTATION 기준) */
-    public ResponseDTO findAllManifest(OutboundRequestDTO outboundRequestDTO);
-
-    /** 폼 데이터 조회 (운송사·차량 목록) */
-    public ResponseDTO findAllOutbound();
-
-    /** 차량 배정 */
-    public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
-
-    /** 송장 발급 */
-    public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
-
-    /** 출고 확정 */
-    public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundService.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundService.java
@@ -1,14 +1,32 @@
 package cloud.weareithero.api.outbound.service;
 
+import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 import cloud.weareithero.dto.ResponseDTO;
 
 public interface OutboundService {
 
-    /** 출고 목록 조회 (필터 + 페이지네이션) */
+    /** 박스 뷰 목록 조회 (OUTBOUND_PACKING 기준) */
     public ResponseDTO findAll(OutboundRequestDTO outboundRequestDTO);
 
     /** 주문 상세 조회 (OUTBOUND 헤더 + ORDER_PRODUCT 목록) */
     public ResponseDTO findOne(int outboundId);
+
+    /** 매니페스트 뷰 목록 조회 (OUTBOUND_TRANSPORTATION 기준) */
+    public ResponseDTO findAllManifest(OutboundRequestDTO outboundRequestDTO);
+
+    /** 폼 데이터 조회 (운송사·차량 목록) */
+    public ResponseDTO findAllOutbound();
+
+    /** 차량 배정 */
+    public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
+
+    /** 송장 발급 */
+    public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
+
+    /** 출고 확정 */
+    public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundService.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundService.java
@@ -8,18 +8,25 @@ import cloud.weareithero.dto.ResponseDTO;
 
 public interface OutboundService {
 
+    /** 박스 뷰 목록 조회 (OUTBOUND_PACKING 기준) */
     public ResponseDTO findAll(OutboundRequestDTO outboundRequestDTO);
 
+    /** 주문 상세 조회 (OUTBOUND 헤더 + ORDER_PRODUCT 목록) */
     public ResponseDTO findOne(int outboundId);
 
+    /** 매니페스트 뷰 목록 조회 (OUTBOUND_TRANSPORTATION 기준) */
     public ResponseDTO findAllManifest(OutboundRequestDTO outboundRequestDTO);
 
+    /** 폼 데이터 조회 (운송사·차량 목록) */
     public ResponseDTO findAllOutbound();
 
+    /** 차량 배정 */
     public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO);
 
+    /** 송장 발급 */
     public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO);
 
+    /** 출고 확정 */
     public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundServiceImp.java
@@ -7,9 +7,17 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 
 import cloud.weareithero.api.outbound.dao.OutboundDao;
+import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
+import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
+import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 import cloud.weareithero.dto.PaginationDTO;
 import cloud.weareithero.dto.ResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -22,19 +30,29 @@ public class OutboundServiceImp implements OutboundService {
 
     private final OutboundDao outboundDao;
 
+    /**
+     * 박스 뷰 목록 조회
+     * - 기준 테이블: OUTBOUND_PACKING (박스 = 패킹 단위)
+     * - summary: OUTBOUND 기준 집계 5종
+     * - list: OUTBOUND_PACKING 목록
+     * - pagination: OUTBOUND 전체 건수 기준
+     */
     @Override
     public ResponseDTO findAll(OutboundRequestDTO outboundRequestDTO) {
         boolean isSuccess = false;
         String message = null;
         Map<String, Object> request = new HashMap<>();
         try {
-            int total = outboundDao.countAll(outboundRequestDTO);
-            PaginationDTO paginationDTO = new PaginationDTO(outboundRequestDTO.getPage(), total, 0);
-
-            List<OutboundDTO> list = outboundDao.findAll(outboundRequestDTO);
-
-            request.put("list", list);
-            request.put("page", paginationDTO);
+            OutboundSummaryDTO summary = outboundDao.findSummary(outboundRequestDTO);
+            List<OutboundPackingDTO> packingList = outboundDao.findAll(outboundRequestDTO);
+            PaginationDTO pagination = PaginationDTO.builder()
+                    .page(outboundRequestDTO.getPage())
+                    .totalCount(summary.getTotal())
+                    .totalPages((int) Math.ceil((double) summary.getTotal() / outboundRequestDTO.getSize()))
+                    .build();
+            request.put("summary", summary);
+            request.put("list", packingList);
+            request.put("pagination", pagination);
             isSuccess = true;
             message = "출고 목록 조회가 완료되었습니다.";
         } catch (Exception e) {
@@ -43,32 +61,277 @@ public class OutboundServiceImp implements OutboundService {
         }
         return ResponseDTO.builder()
                 .status(isSuccess)
-                .message(message)
                 .data(request)
+                .message(message)
                 .build();
     }
 
+    /**
+     * 주문 상세 조회
+     * - OUTBOUND 헤더 (고객사, 주문일, 마감일, 상태)
+     * - ORDER_PRODUCT 목록 (제품명, 수량, 금액)
+     */
     @Override
     public ResponseDTO findOne(int outboundId) {
         boolean isSuccess = false;
         String message = null;
         Map<String, Object> request = new HashMap<>();
         try {
-            OutboundDTO outboundHeader = outboundDao.findbyOutboundId(outboundId);
-            List<OutboundProductDTO> list = outboundDao.findOne(outboundId);
-
-            request.put("outboundHeader", outboundHeader);
-            request.put("list", list);
+            OutboundDTO outbound = outboundDao.findByOutboundId(outboundId);
+            List<OutboundProductDTO> products = outboundDao.findProducts(outboundId);
+            request.put("outbound", outbound);
+            request.put("products", products);
             isSuccess = true;
-            message = "주문 상세 조회가 완료되었습니다.";
+            message = "출고 상세 조회가 완료되었습니다.";
         } catch (Exception e) {
             log.info("OutboundServiceImp findOne error : {}", e.getMessage());
-            message = "주문 상세 조회에 실패했습니다.";
+            message = "출고 상세 조회에 실패했습니다.";
         }
         return ResponseDTO.builder()
                 .status(isSuccess)
-                .message(message)
                 .data(request)
+                .message(message)
                 .build();
     }
+
+    /**
+     * 매니페스트 뷰 목록 조회
+     * - 기준 테이블: OUTBOUND_TRANSPORTATION
+     * - 박스 수: OUTBOUND_PACKING COUNT 집계
+     * ※ totalCount는 별도 COUNT 없이 list.size() 사용 (규모 고려 시 별도 쿼리 추가 권장)
+     */
+    @Override
+    public ResponseDTO findAllManifest(OutboundRequestDTO outboundRequestDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            List<OutboundManifestDTO> manifestList = outboundDao.findAllManifest(outboundRequestDTO);
+            PaginationDTO pagination = PaginationDTO.builder()
+                    .page(outboundRequestDTO.getPage())
+                    .totalCount(manifestList.size())
+                    .totalPages((int) Math.ceil((double) manifestList.size() / outboundRequestDTO.getSize()))
+                    .build();
+            request.put("list", manifestList);
+            request.put("pagination", pagination);
+            isSuccess = true;
+            message = "매니페스트 목록 조회가 완료되었습니다.";
+        } catch (Exception e) {
+            log.info("OutboundServiceImp findAllManifest error : {}", e.getMessage());
+            message = "매니페스트 목록 조회에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+                .status(isSuccess)
+                .data(request)
+                .message(message)
+                .build();
+    }
+
+    /**
+     * 폼 데이터 조회
+     * - 운송사: PARTNER_COMPANY_MASTER WHERE carrier_yn_code = 1
+     * - 차량: TRANSPORTATION_VEHICLE_MASTER 전체
+     */
+    @Override
+    public ResponseDTO findAllOutbound() {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            List<OutboundCarrierDTO> carriers = outboundDao.findByCarrier();
+            List<OutboundTransportationVehicleDTO> vehicles = outboundDao.findByVehicle();
+            request.put("carriers", carriers);
+            request.put("vehicles", vehicles);
+            isSuccess = true;
+            message = "출고 폼 데이터 조회가 완료되었습니다.";
+        } catch (Exception e) {
+            log.info("OutboundServiceImp findAllOutbound error : {}", e.getMessage());
+            message = "출고 폼 데이터 조회에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+                .status(isSuccess)
+                .data(request)
+                .message(message)
+                .build();
+    }
+
+    /**
+     * 차량 배정
+     *
+     * 처리 흐름:
+     * 1) OUTBOUND_TRANSPORTATION INSERT
+     * - useGeneratedKeys 로 transportationId 획득
+     * 2) 선택된 packingIds[] 각각 OUTBOUND_PACKING UPDATE
+     * - outbound_transportation_id = transportationId
+     * - state_code = 차량배정 상태코드
+     * ※ 차량배정 state_code 값 COMMON_CODE 확인 필요 (주석 참고)
+     * 3) Inbound 패턴 동일 - 부분 실패 감지
+     *
+     * ※ 박스 탭에서 체크박스로 선택한 packing_id 목록을 수신
+     * ※ 선택된 박스들은 동일 운송사 소속이어야 함 (프론트 selectedCarrier 가드로 제어 중)
+     */
+    @Override
+    public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            // 1. OUTBOUND_TRANSPORTATION INSERT (lpn, driver, carrier, vehicle, etd)
+            outboundDao.addTransportation(outboundVehicleAssignDTO);
+            int transportationId = outboundVehicleAssignDTO.getTransportationId();
+
+            if (transportationId > 0) {
+                List<Integer> packingIds = outboundVehicleAssignDTO.getPackingIds();
+                int updatedCount = 0;
+
+                // 🟢 [수정 1] COMMON_CODE 테이블에 정의된 '차량배정완료' 상태 코드 번호를 변수에 담습니다.
+                // (만약 디비에 등록된 실제 출고대기/차량배정완료 id 코드가 21번이 아니라 다른 숫자라면 그 숫자를 적어주세요!)
+                int shippingReadyCode = outboundVehicleAssignDTO.getStateCode();
+
+                // 2. 선택된 OUTBOUND_PACKING 각각 UPDATE
+                for (Integer packingId : packingIds) {
+                    updatedCount += outboundDao.updatePackingTransportation(packingId, transportationId,
+                            shippingReadyCode);
+                }
+
+                // 3. 부분 실패 감지 (Inbound 패턴 동일)
+                if (updatedCount == packingIds.size()) {
+                    isSuccess = true;
+                    message = "차량 배정이 완료되었습니다.";
+                } else {
+                    message = "차량 배정이 일부 실패했습니다.";
+                }
+            } else {
+                message = "운송 차량 등록에 실패했습니다.";
+            }
+        } catch (Exception e) {
+            log.info("OutboundServiceImp assignVehicle error : {}", e.getMessage());
+            message = "차량 배정에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+                .status(isSuccess)
+                .data(request)
+                .message(message)
+                .build();
+    }
+
+    /**
+     * 송장 발급
+     *
+     * 처리 흐름:
+     * 1) OUTBOUND_PACKING 상태 가드: 차량배정 완료 상태인지 확인
+     * ※ 차량배정 완료 state_code 값 COMMON_CODE 확인 필요
+     * 2) invoice_number 채번 → DTO에 주입
+     * - 형식: INV-YYYYMMDD-NNN (ServiceImp 레이어에서 채번 권장)
+     * ※ 동시성 처리 방식 팀 결정 필요 (현재: DB의 MAX+1 방식 사용 금지 권장)
+     * 3) OUTBOUND_PACKING UPDATE (invoice_number, state_code 변경)
+     *
+     * ※ packingIds 배열로 복수 박스 일괄 발급 지원
+     * JSX 송장 모달에서 activeInvoiceBoxes(박스번호 목록) 기준으로 일괄 발급 가능
+     */
+    @Override
+    public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            List<Integer> packingIds = outboundInvoiceDTO.getPackingIds();
+            int updatedCount = 0;
+
+            for (Integer packingId : packingIds) {
+                // 상태 가드: 개별 OUTBOUND_PACKING의 state_code 확인
+                OutboundPackingDTO current = outboundDao.findByPackingId(packingId);
+
+                // 🟢 [수정] COMMON_CODE 테이블의 실제 id 값으로 교체합니다.
+                final int STATE_VEHICLE_ASSIGNED = 21; // 차량배정 (21)
+                final int STATE_OUTBOUND_WAITING = 22; // 출고대기 (22)
+
+                if (current == null) {
+                    log.info("OutboundServiceImp issueInvoice - packingId {} not found", packingId);
+                    continue;
+                }
+
+                // 🟢 [수정] 현재 패킹 상태가 '차량배정(21)'도 아니고 '출고대기(22)'도 아닐 때만 튕겨내도록 조건을 변경합니다.
+                if (current.getStateCode() != STATE_VEHICLE_ASSIGNED
+                        && current.getStateCode() != STATE_OUTBOUND_WAITING) {
+                    log.info("OutboundServiceImp issueInvoice - packingId {} state not valid: {}", packingId,
+                            current.getStateCode());
+                    continue;
+                }
+
+                // invoice_number를 DTO에 주입 (채번 로직 팀 결정 후 교체)
+                // 현재: packingId 기반 임시 채번 - 실제 운영 전 동시성 안전한 방식으로 변경 필요
+                // TODO: 채번 방식 결정 필요 (예: DB 시퀀스 테이블, UUID, 날짜+AUTO_INCREMENT 등)
+                outboundInvoiceDTO.setPackingId(packingId);
+                outboundInvoiceDTO.setStateCode(current.getStateCode());
+                updatedCount += outboundDao.updateInvoiceNumber(outboundInvoiceDTO);
+            }
+
+            if (updatedCount == packingIds.size()) {
+                isSuccess = true;
+                message = "송장 발급이 완료되었습니다.";
+            } else if (updatedCount > 0) {
+                message = "송장 발급이 일부 완료되었습니다.";
+            } else {
+                message = "송장 발급에 실패했습니다. 차량 배정 완료 여부를 확인해주세요.";
+            }
+        } catch (Exception e) {
+            log.info("OutboundServiceImp issueInvoice error : {}", e.getMessage());
+            message = "송장 발급에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+                .status(isSuccess)
+                .data(request)
+                .message(message)
+                .build();
+    }
+
+    /**
+     * 출고 확정
+     *
+     * 처리 흐름:
+     * - JSX 기준: 매니페스트 탭에서 체크박스 선택 후 [출고 확정] 버튼 클릭
+     * - 단위: OUTBOUND_TRANSPORTATION (매니페스트) 단위 확정
+     * - transportationIds[] 각각 state_code → 출고완료, atd = NOW() UPDATE
+     * - 부분 실패 감지 (Inbound 패턴 동일)
+     *
+     * ※ 출고완료 state_code 값 COMMON_CODE 확인 필요
+     * ※ OUTBOUND_PACKING의 state_code도 연동 변경이 필요한지 팀 협의 필요
+     * (현재는 OUTBOUND_TRANSPORTATION 만 변경)
+     */
+    @Override
+    public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            List<Integer> transportationIds = outboundConfirmDTO.getTransportationIds();
+
+            // TODO: COMMON_CODE에서 "출고완료" state_code 값 확인 후 교체 필요
+            final int STATE_CONFIRMED = 0; // ← COMMON_CODE 확인 필요
+
+            int updatedCount = 0;
+            for (Integer transportationId : transportationIds) {
+                updatedCount += outboundDao.updateTransportationConfirm(transportationId, STATE_CONFIRMED);
+            }
+
+            if (updatedCount == transportationIds.size()) {
+                isSuccess = true;
+                message = "출고 확정이 완료되었습니다.";
+            } else if (updatedCount > 0) {
+                message = "출고 확정이 일부 실패했습니다.";
+            } else {
+                message = "출고 확정에 실패했습니다.";
+            }
+        } catch (Exception e) {
+            log.info("OutboundServiceImp confirmShipment error : {}", e.getMessage());
+            message = "출고 확정에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+                .status(isSuccess)
+                .data(request)
+                .message(message)
+                .build();
+    }
+
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundServiceImp.java
@@ -7,17 +7,9 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 
 import cloud.weareithero.api.outbound.dao.OutboundDao;
-import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
-import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
-import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
-import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
-import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
-import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
-import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
 import cloud.weareithero.dto.PaginationDTO;
 import cloud.weareithero.dto.ResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -30,29 +22,19 @@ public class OutboundServiceImp implements OutboundService {
 
     private final OutboundDao outboundDao;
 
-    /**
-     * 박스 뷰 목록 조회
-     * - 기준 테이블: OUTBOUND_PACKING (박스 = 패킹 단위)
-     * - summary: OUTBOUND 기준 집계 5종
-     * - list: OUTBOUND_PACKING 목록
-     * - pagination: OUTBOUND 전체 건수 기준
-     */
     @Override
     public ResponseDTO findAll(OutboundRequestDTO outboundRequestDTO) {
         boolean isSuccess = false;
         String message = null;
         Map<String, Object> request = new HashMap<>();
         try {
-            OutboundSummaryDTO summary = outboundDao.findSummary(outboundRequestDTO);
-            List<OutboundPackingDTO> packingList = outboundDao.findAll(outboundRequestDTO);
-            PaginationDTO pagination = PaginationDTO.builder()
-                .page(outboundRequestDTO.getPage())
-                .totalCount(summary.getTotal())
-                .totalPages((int) Math.ceil((double) summary.getTotal() / outboundRequestDTO.getSize()))
-                .build();
-            request.put("summary", summary);
-            request.put("list", packingList);
-            request.put("pagination", pagination);
+            int total = outboundDao.countAll(outboundRequestDTO);
+            PaginationDTO paginationDTO = new PaginationDTO(outboundRequestDTO.getPage(), total, 0);
+
+            List<OutboundDTO> list = outboundDao.findAll(outboundRequestDTO);
+
+            request.put("list", list);
+            request.put("page", paginationDTO);
             isSuccess = true;
             message = "출고 목록 조회가 완료되었습니다.";
         } catch (Exception e) {
@@ -60,268 +42,33 @@ public class OutboundServiceImp implements OutboundService {
             message = "출고 목록 조회에 실패했습니다.";
         }
         return ResponseDTO.builder()
-            .status(isSuccess)
-            .data(request)
-            .message(message)
-            .build();
+                .status(isSuccess)
+                .message(message)
+                .data(request)
+                .build();
     }
 
-    /**
-     * 주문 상세 조회
-     * - OUTBOUND 헤더 (고객사, 주문일, 마감일, 상태)
-     * - ORDER_PRODUCT 목록 (제품명, 수량, 금액)
-     */
     @Override
     public ResponseDTO findOne(int outboundId) {
         boolean isSuccess = false;
         String message = null;
         Map<String, Object> request = new HashMap<>();
         try {
-            OutboundDTO outbound = outboundDao.findByOutboundId(outboundId);
-            List<OutboundProductDTO> products = outboundDao.findProducts(outboundId);
-            request.put("outbound", outbound);
-            request.put("products", products);
+            OutboundDTO outboundHeader = outboundDao.findbyOutboundId(outboundId);
+            List<OutboundProductDTO> list = outboundDao.findOne(outboundId);
+
+            request.put("outboundHeader", outboundHeader);
+            request.put("list", list);
             isSuccess = true;
-            message = "출고 상세 조회가 완료되었습니다.";
+            message = "주문 상세 조회가 완료되었습니다.";
         } catch (Exception e) {
             log.info("OutboundServiceImp findOne error : {}", e.getMessage());
-            message = "출고 상세 조회에 실패했습니다.";
+            message = "주문 상세 조회에 실패했습니다.";
         }
         return ResponseDTO.builder()
-            .status(isSuccess)
-            .data(request)
-            .message(message)
-            .build();
-    }
-
-    /**
-     * 매니페스트 뷰 목록 조회
-     * - 기준 테이블: OUTBOUND_TRANSPORTATION
-     * - 박스 수: OUTBOUND_PACKING COUNT 집계
-     * ※ totalCount는 별도 COUNT 없이 list.size() 사용 (규모 고려 시 별도 쿼리 추가 권장)
-     */
-    @Override
-    public ResponseDTO findAllManifest(OutboundRequestDTO outboundRequestDTO) {
-        boolean isSuccess = false;
-        String message = null;
-        Map<String, Object> request = new HashMap<>();
-        try {
-            List<OutboundManifestDTO> manifestList = outboundDao.findAllManifest(outboundRequestDTO);
-            PaginationDTO pagination = PaginationDTO.builder()
-                .page(outboundRequestDTO.getPage())
-                .totalCount(manifestList.size())
-                .totalPages((int) Math.ceil((double) manifestList.size() / outboundRequestDTO.getSize()))
+                .status(isSuccess)
+                .message(message)
+                .data(request)
                 .build();
-            request.put("list", manifestList);
-            request.put("pagination", pagination);
-            isSuccess = true;
-            message = "매니페스트 목록 조회가 완료되었습니다.";
-        } catch (Exception e) {
-            log.info("OutboundServiceImp findAllManifest error : {}", e.getMessage());
-            message = "매니페스트 목록 조회에 실패했습니다.";
-        }
-        return ResponseDTO.builder()
-            .status(isSuccess)
-            .data(request)
-            .message(message)
-            .build();
     }
-
-    /**
-     * 폼 데이터 조회
-     * - 운송사: PARTNER_COMPANY_MASTER WHERE carrier_yn_code = 1
-     * - 차량: TRANSPORTATION_VEHICLE_MASTER 전체
-     */
-    @Override
-    public ResponseDTO findAllOutbound() {
-        boolean isSuccess = false;
-        String message = null;
-        Map<String, Object> request = new HashMap<>();
-        try {
-            List<OutboundCarrierDTO> carriers = outboundDao.findByCarrier();
-            List<OutboundTransportationVehicleDTO> vehicles = outboundDao.findByVehicle();
-            request.put("carriers", carriers);
-            request.put("vehicles", vehicles);
-            isSuccess = true;
-            message = "출고 폼 데이터 조회가 완료되었습니다.";
-        } catch (Exception e) {
-            log.info("OutboundServiceImp findAllOutbound error : {}", e.getMessage());
-            message = "출고 폼 데이터 조회에 실패했습니다.";
-        }
-        return ResponseDTO.builder()
-            .status(isSuccess)
-            .data(request)
-            .message(message)
-            .build();
-    }
-
-    /**
-     * 차량 배정
-     *
-     * 처리 흐름:
-     *   1) OUTBOUND_TRANSPORTATION INSERT
-     *      - useGeneratedKeys 로 transportationId 획득
-     *   2) 선택된 packingIds[] 각각 OUTBOUND_PACKING UPDATE
-     *      - outbound_transportation_id = transportationId
-     *      - state_code = 차량배정 상태코드
-     *         ※ 차량배정 state_code 값 COMMON_CODE 확인 필요 (주석 참고)
-     *   3) Inbound 패턴 동일 - 부분 실패 감지
-     *
-     * ※ 박스 탭에서 체크박스로 선택한 packing_id 목록을 수신
-     * ※ 선택된 박스들은 동일 운송사 소속이어야 함 (프론트 selectedCarrier 가드로 제어 중)
-     */
-    @Override
-    public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
-        boolean isSuccess = false;
-        String message = null;
-        Map<String, Object> request = new HashMap<>();
-        try {
-            // 1. OUTBOUND_TRANSPORTATION INSERT (lpn, driver, carrier, vehicle, etd)
-            outboundDao.addTransportation(outboundVehicleAssignDTO);
-            int transportationId = outboundVehicleAssignDTO.getTransportationId();
-
-            if (transportationId > 0) {
-                List<Integer> packingIds = outboundVehicleAssignDTO.getPackingIds();
-                int updatedCount = 0;
-
-                // 2. 선택된 OUTBOUND_PACKING 각각 UPDATE
-                for (Integer packingId : packingIds) {
-                    updatedCount += outboundDao.updatePackingTransportation(packingId, transportationId);
-                }
-
-                // 3. 부분 실패 감지 (Inbound 패턴 동일)
-                if (updatedCount == packingIds.size()) {
-                    isSuccess = true;
-                    message = "차량 배정이 완료되었습니다.";
-                } else {
-                    message = "차량 배정이 일부 실패했습니다.";
-                }
-            } else {
-                message = "운송 차량 등록에 실패했습니다.";
-            }
-        } catch (Exception e) {
-            log.info("OutboundServiceImp assignVehicle error : {}", e.getMessage());
-            message = "차량 배정에 실패했습니다.";
-        }
-        return ResponseDTO.builder()
-            .status(isSuccess)
-            .data(request)
-            .message(message)
-            .build();
-    }
-
-    /**
-     * 송장 발급
-     *
-     * 처리 흐름:
-     *   1) OUTBOUND_PACKING 상태 가드: 차량배정 완료 상태인지 확인
-     *      ※ 차량배정 완료 state_code 값 COMMON_CODE 확인 필요
-     *   2) invoice_number 채번 → DTO에 주입
-     *      - 형식: INV-YYYYMMDD-NNN (ServiceImp 레이어에서 채번 권장)
-     *      ※ 동시성 처리 방식 팀 결정 필요 (현재: DB의 MAX+1 방식 사용 금지 권장)
-     *   3) OUTBOUND_PACKING UPDATE (invoice_number, state_code 변경)
-     *
-     * ※ packingIds 배열로 복수 박스 일괄 발급 지원
-     *    JSX 송장 모달에서 activeInvoiceBoxes(박스번호 목록) 기준으로 일괄 발급 가능
-     */
-    @Override
-    public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO) {
-        boolean isSuccess = false;
-        String message = null;
-        Map<String, Object> request = new HashMap<>();
-        try {
-            List<Integer> packingIds = outboundInvoiceDTO.getPackingIds();
-            int updatedCount = 0;
-
-            for (Integer packingId : packingIds) {
-                // 상태 가드: 개별 OUTBOUND_PACKING의 state_code 확인
-                OutboundPackingDTO current = outboundDao.findByPackingId(packingId);
-
-                // TODO: COMMON_CODE에서 "차량배정완료" state_code 값 확인 후 상수 교체 필요
-                // 현재 임시값 0 → 실제 COMMON_CODE id 로 교체
-                final int STATE_VEHICLE_ASSIGNED = 0; // ← COMMON_CODE 확인 필요
-
-                if (current == null) {
-                    log.info("OutboundServiceImp issueInvoice - packingId {} not found", packingId);
-                    continue;
-                }
-                if (current.getStateCode() != STATE_VEHICLE_ASSIGNED) {
-                    log.info("OutboundServiceImp issueInvoice - packingId {} state not valid: {}", packingId, current.getStateCode());
-                    continue;
-                }
-
-                // invoice_number를 DTO에 주입 (채번 로직 팀 결정 후 교체)
-                // 현재: packingId 기반 임시 채번 - 실제 운영 전 동시성 안전한 방식으로 변경 필요
-                // TODO: 채번 방식 결정 필요 (예: DB 시퀀스 테이블, UUID, 날짜+AUTO_INCREMENT 등)
-                outboundInvoiceDTO.setPackingId(packingId);
-                updatedCount += outboundDao.updateInvoiceNumber(outboundInvoiceDTO);
-            }
-
-            if (updatedCount == packingIds.size()) {
-                isSuccess = true;
-                message = "송장 발급이 완료되었습니다.";
-            } else if (updatedCount > 0) {
-                message = "송장 발급이 일부 완료되었습니다.";
-            } else {
-                message = "송장 발급에 실패했습니다. 차량 배정 완료 여부를 확인해주세요.";
-            }
-        } catch (Exception e) {
-            log.info("OutboundServiceImp issueInvoice error : {}", e.getMessage());
-            message = "송장 발급에 실패했습니다.";
-        }
-        return ResponseDTO.builder()
-            .status(isSuccess)
-            .data(request)
-            .message(message)
-            .build();
-    }
-
-    /**
-     * 출고 확정
-     *
-     * 처리 흐름:
-     *   - JSX 기준: 매니페스트 탭에서 체크박스 선택 후 [출고 확정] 버튼 클릭
-     *   - 단위: OUTBOUND_TRANSPORTATION (매니페스트) 단위 확정
-     *   - transportationIds[] 각각 state_code → 출고완료, atd = NOW() UPDATE
-     *   - 부분 실패 감지 (Inbound 패턴 동일)
-     *
-     * ※ 출고완료 state_code 값 COMMON_CODE 확인 필요
-     * ※ OUTBOUND_PACKING의 state_code도 연동 변경이 필요한지 팀 협의 필요
-     *   (현재는 OUTBOUND_TRANSPORTATION 만 변경)
-     */
-    @Override
-    public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO) {
-        boolean isSuccess = false;
-        String message = null;
-        Map<String, Object> request = new HashMap<>();
-        try {
-            List<Integer> transportationIds = outboundConfirmDTO.getTransportationIds();
-
-            // TODO: COMMON_CODE에서 "출고완료" state_code 값 확인 후 교체 필요
-            final int STATE_CONFIRMED = 0; // ← COMMON_CODE 확인 필요
-
-            int updatedCount = 0;
-            for (Integer transportationId : transportationIds) {
-                updatedCount += outboundDao.updateTransportationConfirm(transportationId, STATE_CONFIRMED);
-            }
-
-            if (updatedCount == transportationIds.size()) {
-                isSuccess = true;
-                message = "출고 확정이 완료되었습니다.";
-            } else if (updatedCount > 0) {
-                message = "출고 확정이 일부 실패했습니다.";
-            } else {
-                message = "출고 확정에 실패했습니다.";
-            }
-        } catch (Exception e) {
-            log.info("OutboundServiceImp confirmShipment error : {}", e.getMessage());
-            message = "출고 확정에 실패했습니다.";
-        }
-        return ResponseDTO.builder()
-            .status(isSuccess)
-            .data(request)
-            .message(message)
-            .build();
-    }
-
 }

--- a/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundServiceImp.java
@@ -1,0 +1,298 @@
+package cloud.weareithero.api.outbound.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import cloud.weareithero.api.outbound.dao.OutboundDao;
+import cloud.weareithero.api.outbound.dto.OutboundCarrierDTO;
+import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
+import cloud.weareithero.api.outbound.dto.OutboundDTO;
+import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
+import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
+import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
+import cloud.weareithero.api.outbound.dto.OutboundTransportationVehicleDTO;
+import cloud.weareithero.api.outbound.dto.OutboundVehicleAssignDTO;
+import cloud.weareithero.dto.PaginationDTO;
+import cloud.weareithero.dto.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboundServiceImp implements OutboundService {
+
+    private final OutboundDao outboundDao;
+
+    /**
+     * 박스 뷰 목록 조회
+     * - summary(상단 카드 5종) + list(박스 테이블) + pagination
+     */
+    @Override
+    public ResponseDTO findAll(OutboundRequestDTO outboundRequestDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            OutboundSummaryDTO summary = outboundDao.findSummary(outboundRequestDTO);
+            List<OutboundDTO> outboundList = outboundDao.findAll(outboundRequestDTO);
+            PaginationDTO pagination = PaginationDTO.builder()
+                .page(outboundRequestDTO.getPage())
+                .totalCount(summary.getTotal())
+                .totalPages((int) Math.ceil((double) summary.getTotal() / outboundRequestDTO.getSize()))
+                .build();
+            request.put("summary", summary);
+            request.put("list", outboundList);
+            request.put("pagination", pagination);
+            isSuccess = true;
+            message = "출고 목록 조회가 완료되었습니다.";
+        } catch (Exception e) {
+            log.info("OutboundServiceImp findAll error : {}", e.getMessage());
+            message = "출고 목록 조회에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+            .status(isSuccess)
+            .data(request)
+            .message(message)
+            .build();
+    }
+
+    /**
+     * 주문 상세 내역 조회
+     * - 헤더(주문번호·고객사·상태) + 제품 목록
+     * ※ outboundId는 .id 기준으로 조회
+     */
+    @Override
+    public ResponseDTO findOne(int outboundId) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            OutboundDTO outbound = outboundDao.findByOutboundId(outboundId);
+            List<OutboundProductDTO> products = outboundDao.findProducts(outboundId);
+            request.put("outbound", outbound);
+            request.put("products", products);
+            isSuccess = true;
+            message = "출고 상세 정보 조회가 완료되었습니다.";
+        } catch (Exception e) {
+            log.info("OutboundServiceImp findOne error : {}", e.getMessage());
+            message = "출고 상세 정보 조회에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+            .status(isSuccess)
+            .data(request)
+            .message(message)
+            .build();
+    }
+
+    /**
+     * 매니페스트 뷰 목록 조회
+     * - OUTBOUND_TRANSPORTATION 기준으로 운송 단위 집계
+     */
+    @Override
+    public ResponseDTO findAllManifest(OutboundRequestDTO outboundRequestDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            List<OutboundManifestDTO> manifestList = outboundDao.findAllManifest(outboundRequestDTO);
+            PaginationDTO pagination = PaginationDTO.builder()
+                .page(outboundRequestDTO.getPage())
+                .totalCount(manifestList.size())
+                .totalPages((int) Math.ceil((double) manifestList.size() / outboundRequestDTO.getSize()))
+                .build();
+            request.put("list", manifestList);
+            request.put("pagination", pagination);
+            isSuccess = true;
+            message = "매니페스트 목록 조회가 완료되었습니다.";
+        } catch (Exception e) {
+            log.info("OutboundServiceImp findAllManifest error : {}", e.getMessage());
+            message = "매니페스트 목록 조회에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+            .status(isSuccess)
+            .data(request)
+            .message(message)
+            .build();
+    }
+
+    /**
+     * 폼 데이터 조회 (차량 배정 모달 드롭다운용)
+     * - 운송사(carriers) + 차량 목록(vehicles)
+     */
+    @Override
+    public ResponseDTO findAllOutbound() {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            List<OutboundCarrierDTO> carriers = outboundDao.findByCarrier();
+            List<OutboundTransportationVehicleDTO> vehicles = outboundDao.findByVehicle();
+            request.put("carriers", carriers);
+            request.put("vehicles", vehicles);
+            isSuccess = true;
+            message = "출고 폼 데이터 조회가 완료되었습니다.";
+        } catch (Exception e) {
+            log.info("OutboundServiceImp findAllOutbound error : {}", e.getMessage());
+            message = "출고 폼 데이터 조회에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+            .status(isSuccess)
+            .data(request)
+            .message(message)
+            .build();
+    }
+
+    /**
+     * 차량 배정
+     * 처리 순서:
+     * 1. OUTBOUND_TRANSPORTATION INSERT → PK(transportationId) 획득
+     * 2. 선택된 outboundIds[] 각각에 transportationId UPDATE
+     * 3. 부분 실패 감지 (Inbound addOrderMaterial 패턴 동일 적용)
+     *
+     * ※ 상태 가드: 대상 OUTBOUND의 state_code가 "미배정" 상태인지 확인 필요
+     *   (현재 state_code 값 체계는 COMMON_CODE 테이블 확인 필요 — ERD 확인 항목)
+     */
+    @Override
+    public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            // 1. OUTBOUND_TRANSPORTATION 헤더 INSERT
+            int transportationId = outboundDao.addTransportation(outboundVehicleAssignDTO);
+
+            if (transportationId > 0) {
+                List<Integer> outboundIds = outboundVehicleAssignDTO.getOutboundIds();
+                int updatedCount = 0;
+
+                // 2. 선택된 박스 각각에 transportationId 연결 UPDATE
+                for (Integer outboundId : outboundIds) {
+                    updatedCount += outboundDao.updateTransportationId(outboundId, transportationId);
+                }
+
+                // 3. 부분 실패 감지 (Inbound 패턴 동일)
+                if (updatedCount == outboundIds.size()) {
+                    isSuccess = true;
+                    message = "차량 배정이 완료되었습니다.";
+                } else {
+                    message = "차량 배정이 일부 실패했습니다.";
+                }
+            } else {
+                message = "차량 배정 등록에 실패했습니다.";
+            }
+        } catch (Exception e) {
+            log.info("OutboundServiceImp assignVehicle error : {}", e.getMessage());
+            message = "차량 배정에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+            .status(isSuccess)
+            .data(request)
+            .message(message)
+            .build();
+    }
+
+    /**
+     * 송장 발급
+     * 처리 순서:
+     * 1. 상태 가드: 해당 OUTBOUND의 state_code가 "차량배정" 완료 상태인지 검증
+     * 2. 송장번호 채번 (현재 MAX 방식 사용 — 동시성 처리는 추가 검토 필요)
+     * 3. OUTBOUND UPDATE (invoice_no 저장, state_code 변경)
+     *
+     * ※ invoice_no 컬럼 존재 여부 ERD 확인 필요
+     * ※ "차량배정 완료" state_code 값 COMMON_CODE 확인 필요
+     */
+    @Override
+    public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            // 1. 상태 가드: 차량 배정 완료 여부 확인
+            OutboundDTO current = outboundDao.findByOutboundId(outboundInvoiceDTO.getOutboundId());
+
+            // TODO: COMMON_CODE에서 "차량배정완료" state_code 값 확인 후 아래 상수 교체 필요
+            // 현재 Inbound 기준 state_code 4 = 예정, 5 = 완료 → Outbound 값은 별도 확인
+            final int STATE_VEHICLE_ASSIGNED = 0; // ← ERD/COMMON_CODE 확인 필요
+
+            if (current == null) {
+                message = "해당 출고 정보를 찾을 수 없습니다.";
+            } else if (current.getStateCode() != STATE_VEHICLE_ASSIGNED) {
+                message = "차량 배정 완료 후 송장 발급이 가능합니다.";
+            } else {
+                // 2. 송장번호 채번 후 UPDATE
+                int result = outboundDao.updateInvoice(outboundInvoiceDTO);
+                if (result > 0) {
+                    isSuccess = true;
+                    message = "송장 발급이 완료되었습니다.";
+                } else {
+                    message = "송장 발급에 실패했습니다.";
+                }
+            }
+        } catch (Exception e) {
+            log.info("OutboundServiceImp issueInvoice error : {}", e.getMessage());
+            message = "송장 발급에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+            .status(isSuccess)
+            .data(request)
+            .message(message)
+            .build();
+    }
+
+    /**
+     * 출고 확정
+     * 처리 순서:
+     * 1. 상태 가드: 해당 OUTBOUND의 state_code가 "송장발급" 완료 상태인지 검증
+     * 2. 선택된 outboundIds[] 각각 state_code → "출고확정" UPDATE
+     * 3. 부분 실패 감지 (Inbound 패턴 동일 적용)
+     *
+     * ※ "송장발급 완료" state_code 값 COMMON_CODE 확인 필요
+     * ※ "출고확정" state_code 값 COMMON_CODE 확인 필요
+     */
+    @Override
+    public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO) {
+        boolean isSuccess = false;
+        String message = null;
+        Map<String, Object> request = new HashMap<>();
+        try {
+            List<Integer> outboundIds = outboundConfirmDTO.getOutboundIds();
+
+            // TODO: COMMON_CODE에서 "송장발급완료" state_code 값 확인 후 교체 필요
+            final int STATE_INVOICE_ISSUED = 0;  // ← ERD/COMMON_CODE 확인 필요
+            final int STATE_CONFIRMED      = 0;  // ← ERD/COMMON_CODE 확인 필요
+
+            int updatedCount = 0;
+            for (Integer outboundId : outboundIds) {
+                // 상태 가드: 개별 건 단위로 송장발급 완료 여부 확인 후 UPDATE
+                OutboundDTO current = outboundDao.findByOutboundId(outboundId);
+                if (current != null && current.getStateCode() == STATE_INVOICE_ISSUED) {
+                    updatedCount += outboundDao.updateStateCode(outboundId, STATE_CONFIRMED);
+                }
+            }
+
+            if (updatedCount == outboundIds.size()) {
+                isSuccess = true;
+                message = "출고 확정이 완료되었습니다.";
+            } else if (updatedCount > 0) {
+                message = "출고 확정이 일부 실패했습니다.";
+            } else {
+                message = "출고 확정에 실패했습니다. 송장 발급 완료 여부를 확인해주세요.";
+            }
+        } catch (Exception e) {
+            log.info("OutboundServiceImp confirmShipment error : {}", e.getMessage());
+            message = "출고 확정에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+            .status(isSuccess)
+            .data(request)
+            .message(message)
+            .build();
+    }
+
+}

--- a/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/outbound/service/OutboundServiceImp.java
@@ -12,6 +12,7 @@ import cloud.weareithero.api.outbound.dto.OutboundConfirmDTO;
 import cloud.weareithero.api.outbound.dto.OutboundDTO;
 import cloud.weareithero.api.outbound.dto.OutboundInvoiceDTO;
 import cloud.weareithero.api.outbound.dto.OutboundManifestDTO;
+import cloud.weareithero.api.outbound.dto.OutboundPackingDTO;
 import cloud.weareithero.api.outbound.dto.OutboundProductDTO;
 import cloud.weareithero.api.outbound.dto.OutboundRequestDTO;
 import cloud.weareithero.api.outbound.dto.OutboundSummaryDTO;
@@ -31,7 +32,10 @@ public class OutboundServiceImp implements OutboundService {
 
     /**
      * 박스 뷰 목록 조회
-     * - summary(상단 카드 5종) + list(박스 테이블) + pagination
+     * - 기준 테이블: OUTBOUND_PACKING (박스 = 패킹 단위)
+     * - summary: OUTBOUND 기준 집계 5종
+     * - list: OUTBOUND_PACKING 목록
+     * - pagination: OUTBOUND 전체 건수 기준
      */
     @Override
     public ResponseDTO findAll(OutboundRequestDTO outboundRequestDTO) {
@@ -40,14 +44,14 @@ public class OutboundServiceImp implements OutboundService {
         Map<String, Object> request = new HashMap<>();
         try {
             OutboundSummaryDTO summary = outboundDao.findSummary(outboundRequestDTO);
-            List<OutboundDTO> outboundList = outboundDao.findAll(outboundRequestDTO);
+            List<OutboundPackingDTO> packingList = outboundDao.findAll(outboundRequestDTO);
             PaginationDTO pagination = PaginationDTO.builder()
                 .page(outboundRequestDTO.getPage())
                 .totalCount(summary.getTotal())
                 .totalPages((int) Math.ceil((double) summary.getTotal() / outboundRequestDTO.getSize()))
                 .build();
             request.put("summary", summary);
-            request.put("list", outboundList);
+            request.put("list", packingList);
             request.put("pagination", pagination);
             isSuccess = true;
             message = "출고 목록 조회가 완료되었습니다.";
@@ -63,9 +67,9 @@ public class OutboundServiceImp implements OutboundService {
     }
 
     /**
-     * 주문 상세 내역 조회
-     * - 헤더(주문번호·고객사·상태) + 제품 목록
-     * ※ outboundId는 .id 기준으로 조회
+     * 주문 상세 조회
+     * - OUTBOUND 헤더 (고객사, 주문일, 마감일, 상태)
+     * - ORDER_PRODUCT 목록 (제품명, 수량, 금액)
      */
     @Override
     public ResponseDTO findOne(int outboundId) {
@@ -78,10 +82,10 @@ public class OutboundServiceImp implements OutboundService {
             request.put("outbound", outbound);
             request.put("products", products);
             isSuccess = true;
-            message = "출고 상세 정보 조회가 완료되었습니다.";
+            message = "출고 상세 조회가 완료되었습니다.";
         } catch (Exception e) {
             log.info("OutboundServiceImp findOne error : {}", e.getMessage());
-            message = "출고 상세 정보 조회에 실패했습니다.";
+            message = "출고 상세 조회에 실패했습니다.";
         }
         return ResponseDTO.builder()
             .status(isSuccess)
@@ -92,7 +96,9 @@ public class OutboundServiceImp implements OutboundService {
 
     /**
      * 매니페스트 뷰 목록 조회
-     * - OUTBOUND_TRANSPORTATION 기준으로 운송 단위 집계
+     * - 기준 테이블: OUTBOUND_TRANSPORTATION
+     * - 박스 수: OUTBOUND_PACKING COUNT 집계
+     * ※ totalCount는 별도 COUNT 없이 list.size() 사용 (규모 고려 시 별도 쿼리 추가 권장)
      */
     @Override
     public ResponseDTO findAllManifest(OutboundRequestDTO outboundRequestDTO) {
@@ -122,8 +128,9 @@ public class OutboundServiceImp implements OutboundService {
     }
 
     /**
-     * 폼 데이터 조회 (차량 배정 모달 드롭다운용)
-     * - 운송사(carriers) + 차량 목록(vehicles)
+     * 폼 데이터 조회
+     * - 운송사: PARTNER_COMPANY_MASTER WHERE carrier_yn_code = 1
+     * - 차량: TRANSPORTATION_VEHICLE_MASTER 전체
      */
     @Override
     public ResponseDTO findAllOutbound() {
@@ -150,13 +157,18 @@ public class OutboundServiceImp implements OutboundService {
 
     /**
      * 차량 배정
-     * 처리 순서:
-     * 1. OUTBOUND_TRANSPORTATION INSERT → PK(transportationId) 획득
-     * 2. 선택된 outboundIds[] 각각에 transportationId UPDATE
-     * 3. 부분 실패 감지 (Inbound addOrderMaterial 패턴 동일 적용)
      *
-     * ※ 상태 가드: 대상 OUTBOUND의 state_code가 "미배정" 상태인지 확인 필요
-     *   (현재 state_code 값 체계는 COMMON_CODE 테이블 확인 필요 — ERD 확인 항목)
+     * 처리 흐름:
+     *   1) OUTBOUND_TRANSPORTATION INSERT
+     *      - useGeneratedKeys 로 transportationId 획득
+     *   2) 선택된 packingIds[] 각각 OUTBOUND_PACKING UPDATE
+     *      - outbound_transportation_id = transportationId
+     *      - state_code = 차량배정 상태코드
+     *         ※ 차량배정 state_code 값 COMMON_CODE 확인 필요 (주석 참고)
+     *   3) Inbound 패턴 동일 - 부분 실패 감지
+     *
+     * ※ 박스 탭에서 체크박스로 선택한 packing_id 목록을 수신
+     * ※ 선택된 박스들은 동일 운송사 소속이어야 함 (프론트 selectedCarrier 가드로 제어 중)
      */
     @Override
     public ResponseDTO assignVehicle(OutboundVehicleAssignDTO outboundVehicleAssignDTO) {
@@ -164,27 +176,28 @@ public class OutboundServiceImp implements OutboundService {
         String message = null;
         Map<String, Object> request = new HashMap<>();
         try {
-            // 1. OUTBOUND_TRANSPORTATION 헤더 INSERT
-            int transportationId = outboundDao.addTransportation(outboundVehicleAssignDTO);
+            // 1. OUTBOUND_TRANSPORTATION INSERT (lpn, driver, carrier, vehicle, etd)
+            outboundDao.addTransportation(outboundVehicleAssignDTO);
+            int transportationId = outboundVehicleAssignDTO.getTransportationId();
 
             if (transportationId > 0) {
-                List<Integer> outboundIds = outboundVehicleAssignDTO.getOutboundIds();
+                List<Integer> packingIds = outboundVehicleAssignDTO.getPackingIds();
                 int updatedCount = 0;
 
-                // 2. 선택된 박스 각각에 transportationId 연결 UPDATE
-                for (Integer outboundId : outboundIds) {
-                    updatedCount += outboundDao.updateTransportationId(outboundId, transportationId);
+                // 2. 선택된 OUTBOUND_PACKING 각각 UPDATE
+                for (Integer packingId : packingIds) {
+                    updatedCount += outboundDao.updatePackingTransportation(packingId, transportationId);
                 }
 
                 // 3. 부분 실패 감지 (Inbound 패턴 동일)
-                if (updatedCount == outboundIds.size()) {
+                if (updatedCount == packingIds.size()) {
                     isSuccess = true;
                     message = "차량 배정이 완료되었습니다.";
                 } else {
                     message = "차량 배정이 일부 실패했습니다.";
                 }
             } else {
-                message = "차량 배정 등록에 실패했습니다.";
+                message = "운송 차량 등록에 실패했습니다.";
             }
         } catch (Exception e) {
             log.info("OutboundServiceImp assignVehicle error : {}", e.getMessage());
@@ -199,13 +212,17 @@ public class OutboundServiceImp implements OutboundService {
 
     /**
      * 송장 발급
-     * 처리 순서:
-     * 1. 상태 가드: 해당 OUTBOUND의 state_code가 "차량배정" 완료 상태인지 검증
-     * 2. 송장번호 채번 (현재 MAX 방식 사용 — 동시성 처리는 추가 검토 필요)
-     * 3. OUTBOUND UPDATE (invoice_no 저장, state_code 변경)
      *
-     * ※ invoice_no 컬럼 존재 여부 ERD 확인 필요
-     * ※ "차량배정 완료" state_code 값 COMMON_CODE 확인 필요
+     * 처리 흐름:
+     *   1) OUTBOUND_PACKING 상태 가드: 차량배정 완료 상태인지 확인
+     *      ※ 차량배정 완료 state_code 값 COMMON_CODE 확인 필요
+     *   2) invoice_number 채번 → DTO에 주입
+     *      - 형식: INV-YYYYMMDD-NNN (ServiceImp 레이어에서 채번 권장)
+     *      ※ 동시성 처리 방식 팀 결정 필요 (현재: DB의 MAX+1 방식 사용 금지 권장)
+     *   3) OUTBOUND_PACKING UPDATE (invoice_number, state_code 변경)
+     *
+     * ※ packingIds 배열로 복수 박스 일괄 발급 지원
+     *    JSX 송장 모달에서 activeInvoiceBoxes(박스번호 목록) 기준으로 일괄 발급 가능
      */
     @Override
     public ResponseDTO issueInvoice(OutboundInvoiceDTO outboundInvoiceDTO) {
@@ -213,26 +230,40 @@ public class OutboundServiceImp implements OutboundService {
         String message = null;
         Map<String, Object> request = new HashMap<>();
         try {
-            // 1. 상태 가드: 차량 배정 완료 여부 확인
-            OutboundDTO current = outboundDao.findByOutboundId(outboundInvoiceDTO.getOutboundId());
+            List<Integer> packingIds = outboundInvoiceDTO.getPackingIds();
+            int updatedCount = 0;
 
-            // TODO: COMMON_CODE에서 "차량배정완료" state_code 값 확인 후 아래 상수 교체 필요
-            // 현재 Inbound 기준 state_code 4 = 예정, 5 = 완료 → Outbound 값은 별도 확인
-            final int STATE_VEHICLE_ASSIGNED = 0; // ← ERD/COMMON_CODE 확인 필요
+            for (Integer packingId : packingIds) {
+                // 상태 가드: 개별 OUTBOUND_PACKING의 state_code 확인
+                OutboundPackingDTO current = outboundDao.findByPackingId(packingId);
 
-            if (current == null) {
-                message = "해당 출고 정보를 찾을 수 없습니다.";
-            } else if (current.getStateCode() != STATE_VEHICLE_ASSIGNED) {
-                message = "차량 배정 완료 후 송장 발급이 가능합니다.";
-            } else {
-                // 2. 송장번호 채번 후 UPDATE
-                int result = outboundDao.updateInvoice(outboundInvoiceDTO);
-                if (result > 0) {
-                    isSuccess = true;
-                    message = "송장 발급이 완료되었습니다.";
-                } else {
-                    message = "송장 발급에 실패했습니다.";
+                // TODO: COMMON_CODE에서 "차량배정완료" state_code 값 확인 후 상수 교체 필요
+                // 현재 임시값 0 → 실제 COMMON_CODE id 로 교체
+                final int STATE_VEHICLE_ASSIGNED = 0; // ← COMMON_CODE 확인 필요
+
+                if (current == null) {
+                    log.info("OutboundServiceImp issueInvoice - packingId {} not found", packingId);
+                    continue;
                 }
+                if (current.getStateCode() != STATE_VEHICLE_ASSIGNED) {
+                    log.info("OutboundServiceImp issueInvoice - packingId {} state not valid: {}", packingId, current.getStateCode());
+                    continue;
+                }
+
+                // invoice_number를 DTO에 주입 (채번 로직 팀 결정 후 교체)
+                // 현재: packingId 기반 임시 채번 - 실제 운영 전 동시성 안전한 방식으로 변경 필요
+                // TODO: 채번 방식 결정 필요 (예: DB 시퀀스 테이블, UUID, 날짜+AUTO_INCREMENT 등)
+                outboundInvoiceDTO.setPackingId(packingId);
+                updatedCount += outboundDao.updateInvoiceNumber(outboundInvoiceDTO);
+            }
+
+            if (updatedCount == packingIds.size()) {
+                isSuccess = true;
+                message = "송장 발급이 완료되었습니다.";
+            } else if (updatedCount > 0) {
+                message = "송장 발급이 일부 완료되었습니다.";
+            } else {
+                message = "송장 발급에 실패했습니다. 차량 배정 완료 여부를 확인해주세요.";
             }
         } catch (Exception e) {
             log.info("OutboundServiceImp issueInvoice error : {}", e.getMessage());
@@ -247,13 +278,16 @@ public class OutboundServiceImp implements OutboundService {
 
     /**
      * 출고 확정
-     * 처리 순서:
-     * 1. 상태 가드: 해당 OUTBOUND의 state_code가 "송장발급" 완료 상태인지 검증
-     * 2. 선택된 outboundIds[] 각각 state_code → "출고확정" UPDATE
-     * 3. 부분 실패 감지 (Inbound 패턴 동일 적용)
      *
-     * ※ "송장발급 완료" state_code 값 COMMON_CODE 확인 필요
-     * ※ "출고확정" state_code 값 COMMON_CODE 확인 필요
+     * 처리 흐름:
+     *   - JSX 기준: 매니페스트 탭에서 체크박스 선택 후 [출고 확정] 버튼 클릭
+     *   - 단위: OUTBOUND_TRANSPORTATION (매니페스트) 단위 확정
+     *   - transportationIds[] 각각 state_code → 출고완료, atd = NOW() UPDATE
+     *   - 부분 실패 감지 (Inbound 패턴 동일)
+     *
+     * ※ 출고완료 state_code 값 COMMON_CODE 확인 필요
+     * ※ OUTBOUND_PACKING의 state_code도 연동 변경이 필요한지 팀 협의 필요
+     *   (현재는 OUTBOUND_TRANSPORTATION 만 변경)
      */
     @Override
     public ResponseDTO confirmShipment(OutboundConfirmDTO outboundConfirmDTO) {
@@ -261,28 +295,23 @@ public class OutboundServiceImp implements OutboundService {
         String message = null;
         Map<String, Object> request = new HashMap<>();
         try {
-            List<Integer> outboundIds = outboundConfirmDTO.getOutboundIds();
+            List<Integer> transportationIds = outboundConfirmDTO.getTransportationIds();
 
-            // TODO: COMMON_CODE에서 "송장발급완료" state_code 값 확인 후 교체 필요
-            final int STATE_INVOICE_ISSUED = 0;  // ← ERD/COMMON_CODE 확인 필요
-            final int STATE_CONFIRMED      = 0;  // ← ERD/COMMON_CODE 확인 필요
+            // TODO: COMMON_CODE에서 "출고완료" state_code 값 확인 후 교체 필요
+            final int STATE_CONFIRMED = 0; // ← COMMON_CODE 확인 필요
 
             int updatedCount = 0;
-            for (Integer outboundId : outboundIds) {
-                // 상태 가드: 개별 건 단위로 송장발급 완료 여부 확인 후 UPDATE
-                OutboundDTO current = outboundDao.findByOutboundId(outboundId);
-                if (current != null && current.getStateCode() == STATE_INVOICE_ISSUED) {
-                    updatedCount += outboundDao.updateStateCode(outboundId, STATE_CONFIRMED);
-                }
+            for (Integer transportationId : transportationIds) {
+                updatedCount += outboundDao.updateTransportationConfirm(transportationId, STATE_CONFIRMED);
             }
 
-            if (updatedCount == outboundIds.size()) {
+            if (updatedCount == transportationIds.size()) {
                 isSuccess = true;
                 message = "출고 확정이 완료되었습니다.";
             } else if (updatedCount > 0) {
                 message = "출고 확정이 일부 실패했습니다.";
             } else {
-                message = "출고 확정에 실패했습니다. 송장 발급 완료 여부를 확인해주세요.";
+                message = "출고 확정에 실패했습니다.";
             }
         } catch (Exception e) {
             log.info("OutboundServiceImp confirmShipment error : {}", e.getMessage());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "dev_highgooh",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #25 

## 📝 작업 내용
**DB 변경에 의한 코드 수정**
주문 outbound API (7개) 기능 구현
- post/outbound : 박스 목록 조회 (필터 + 페이지네이션)
- post/outbound/{outboundId} : 주문 상세 내역 조회 (제품 목록 포함)
- post/outbound/manifest : 매니페스트 목록 조회
- get/outbound : 폼 데이터 조회 (운송사·차량 목록)
- put/outbound/vehicle : 차량 배정 저장
- put/outbound/invoice : 송장 발급
- put/outbound/confirm : 출고 확정

## 💬 리뷰 포인트
- 모든 시나리오에 부합하게 작동하는지
- React와 연결시 FE와 함께 체크하며 기능 확인 필요
 
