### PR TITLE
주문 FE 및 BE 연동 완료(#61)

### DIFF
--- a/backend/src/main/java/cloud/weareithero/api/order/OrderController.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/OrderController.java
@@ -1,6 +1,5 @@
 package cloud.weareithero.api.order;
 
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/src/main/java/cloud/weareithero/api/order/dao/OrderMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dao/OrderMapper.java
@@ -2,7 +2,6 @@ package cloud.weareithero.api.order.dao;
 
 import java.util.List;
 
-import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -198,21 +197,23 @@ public interface OrderMapper {
   // 5. 주문 마스터 INSERT (OUTBOUND 테이블)
   // [DB 변경] 테이블: ORDER_PRODUCT_LIST → OUTBOUND
   // [DB 변경] keyProperty: orderId → outboundId
-  // [DB 변경] state_code: DB DEFAULT 의존 (명시 미삽입)
-  // [DB 변경] etd, updated_at: 등록 시 미포함, 이후 업데이트
-  //
-  // TODO: OUTBOUND.state_code DEFAULT 값이 DB에 없어서
-  // INSERT 시 state_code 컬럼 추가하고 초기값 하드코딩 필요
+  // 💡 [수정완료] 빠져있던 etd, state_code, total_quantity 컬럼 및 매핑 추가
   // ──────────────────────────────────────────────────────────────
   @Insert("""
       INSERT INTO `OUTBOUND` (
         `partner_company_id`,
         `order_date`,
-        `deadline`
+        `deadline`,
+        `etd`,
+        `state_code`,
+        `total_quantity`
       ) VALUES (
         #{partnerCompanyId},
         #{orderDate},
-        #{deadline}
+        #{deadline},
+        #{etd},
+        #{stateCode},
+        #{totalQuantity}
       )
       """)
   @Options(useGeneratedKeys = true, keyProperty = "outboundId", keyColumn = "id")

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderAddDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderAddDTO.java
@@ -15,12 +15,10 @@ import lombok.ToString;
  * OrderAddDTO - 신규 주문 등록 요청
  *
  * [DB] OUTBOUND 테이블 기준:
- *   customerCompanyId → partner_company_id
- *   orderDate         → order_date
- *   deadline          → deadline
- *   TODO: JSX OrderModal에서 '출고마감일자(deliveryDeadline)' 입력값을
- *         deadline으로 매핑할지 etd로 매핑할지 프론트와 협의 필요
- *         현재는 deadline으로 처리
+ * customerCompanyId → partner_company_id
+ * orderDate         → order_date
+ * deadline          → deadline (주문마감일자)
+ * etd               → etd (출고마감일자)
  */
 @Setter @Getter @ToString
 @AllArgsConstructor
@@ -36,9 +34,13 @@ public class OrderAddDTO {
   @Schema(description = "주문일자 (yyyy-MM-dd)", example = "2026-06-09")
   private String orderDate;
 
-  @NotBlank(message = "출고마감일자를 입력하세요.")
-  @Schema(description = "출고마감일자 (yyyy-MM-dd) → OUTBOUND.deadline", example = "2026-06-25")
+  @NotBlank(message = "주문마감일자를 입력하세요.")
+  @Schema(description = "주문마감일자 (yyyy-MM-dd) → OUTBOUND.deadline", example = "2026-06-24")
   private String deadline;
+
+  @NotBlank(message = "출고마감일자를 입력하세요.") // 👈 형식을 맞춘 Validation 가드 추가
+  @Schema(description = "출고마감일자 (yyyy-MM-dd) → OUTBOUND.etd", example = "2026-06-25") // 👈 Swagger 문서화 양식 매핑
+  private String etd; // 👈 드디어 자바 그릇에 etd 안착!
 
   @Schema(description = "주문 품목 목록")
   private List<OrderDetailProductDTO> items;

--- a/backend/src/main/java/cloud/weareithero/api/order/dto/OrderDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/dto/OrderDTO.java
@@ -1,6 +1,7 @@
 package cloud.weareithero.api.order.dto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,7 +31,10 @@ public class OrderDTO {
   private String partnerName;      // PARTNER_COMPANY_MASTER.name (JOIN)
   private LocalDate orderDate;     // OUTBOUND.order_date
   private LocalDate deadline;      // OUTBOUND.deadline
+  private java.time.LocalDate etd;
   private Long totalPrice;         // ORDER_PRODUCT.total_price SUM (목록 집계용)
+  private Integer totalQuantity;
   private String stateCode;        // COMMON_CODE.name (상태명 문자열)
+  private List<OrderProductDTO> items;
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/order/service/OrderServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/order/service/OrderServiceImp.java
@@ -26,12 +26,12 @@ import lombok.extern.slf4j.Slf4j;
  * Order ServiceImpl
  *
  * [DB 변경] OUTBOUND 테이블이 주문 헤더
- *           ORDER_PRODUCT 테이블이 주문 품목 (outbound_id FK)
+ * ORDER_PRODUCT 테이블이 주문 품목 (outbound_id FK)
  *
  * Inbound 패턴 완전 유지:
- *   - try-catch + isSuccess + ResponseDTO.builder() 패턴
- *   - 복합 등록: OUTBOUND INSERT → useGeneratedKeys → ORDER_PRODUCT 반복 INSERT
- *   - 로그: log.info() 레벨
+ * - try-catch + isSuccess + ResponseDTO.builder() 패턴
+ * - 복합 등록: OUTBOUND INSERT → useGeneratedKeys → ORDER_PRODUCT 반복 INSERT
+ * - 로그: log.info() 레벨
  */
 @Slf4j
 @Service
@@ -100,9 +100,9 @@ public class OrderServiceImp implements OrderService {
 
   // ─────────────────────────────────────────────
   // 3. 신규 주문 등록
-  //    Inbound add() 복합 등록 패턴 동일:
-  //    OUTBOUND INSERT → useGeneratedKeys로 outboundId 획득
-  //    → ORDER_PRODUCT 반복 INSERT → 건수 비교
+  // Inbound add() 복합 등록 패턴 동일:
+  // OUTBOUND INSERT → useGeneratedKeys로 outboundId 획득
+  // → ORDER_PRODUCT 반복 INSERT → 건수 비교
   // ─────────────────────────────────────────────
   @Override
   public ResponseDTO add(OrderAddDTO orderAddDTO) {
@@ -113,12 +113,25 @@ public class OrderServiceImp implements OrderService {
       DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
       int itemCount = (orderAddDTO.getItems() == null) ? 0 : orderAddDTO.getItems().size();
 
+      // 💡 [수정] 1. 하위 제품 항목들을 돌며 총 주문 수량(totalQuantity) 먼저 계산
+      int totalQty = 0;
+      if (itemCount > 0) {
+        for (OrderDetailProductDTO item : orderAddDTO.getItems()) {
+          totalQty += item.getQuantity();
+        }
+      }
+
       // OUTBOUND 헤더 INSERT용 DTO 구성
-      // [DB 변경] ORDER_PRODUCT_LIST → OUTBOUND, state_code 미포함(DB DEFAULT 의존)
+      // 💡 [수정] 2. etd 파싱 추가, 계산한 totalQuantity 주입, 초기 상태 코드(7: 주문접수) 주입 완료
       OrderDTO orderDTO = OrderDTO.builder()
           .partnerCompanyId(orderAddDTO.getCustomerCompanyId())
           .orderDate(LocalDate.parse(orderAddDTO.getOrderDate(), formatter))
           .deadline(LocalDate.parse(orderAddDTO.getDeadline(), formatter))
+          .etd(orderAddDTO.getEtd() != null && !orderAddDTO.getEtd().isEmpty()
+              ? LocalDate.parse(orderAddDTO.getEtd(), formatter)
+              : null)
+          .totalQuantity(totalQty)
+          .stateCode("7") // 👈 목록 조회 BETWEEN 7 AND 9 조건에 부합하도록 초기값 '7' 강제 부여
           .build();
 
       // OUTBOUND INSERT (useGeneratedKeys → orderDTO.outboundId에 PK 주입)
@@ -132,9 +145,8 @@ public class OrderServiceImp implements OrderService {
           int size = 0;
           for (OrderDetailProductDTO item : orderAddDTO.getItems()) {
             // [DB 변경] ORDER_PRODUCT INSERT:
-            //   outbound_id FK = 방금 생성된 outboundId
-            //   price, total_price 모두 클라이언트 전달값 저장
-            //   (서버 재계산 여부는 팀 정책에 따라 결정 필요)
+            // outbound_id FK = 방금 생성된 outboundId
+            // price, total_price 모두 클라이언트 전달값 저장
             OrderDetailProductDTO detailDTO = OrderDetailProductDTO.builder()
                 .outboundId(orderDTO.getOutboundId())
                 .outboundProductId(item.getOutboundProductId())
@@ -163,15 +175,15 @@ public class OrderServiceImp implements OrderService {
 
   // ─────────────────────────────────────────────
   // 4. 주문 수정
-  //    [신규] Inbound에 없던 기능
-  //    OUTBOUND 헤더(deadline, state_code) 수정
-  //    ORDER_PRODUCT 품목 수정 (quantity, price, total_price)
+  // [신규] Inbound에 없던 기능
+  // OUTBOUND 헤더(deadline, state_code) 수정
+  // ORDER_PRODUCT 품목 수정 (quantity, price, total_price)
   //
-  //    TODO: 품목 수정 전략 결정 필요
-  //          현재는 "기존 품목 전체 삭제 후 재삽입" 방식으로 구현
-  //          항목별 UPDATE 방식이 필요하면 orderDao.updateOrderProduct() 별도 추가
+  // TODO: 품목 수정 전략 결정 필요
+  // 현재는 "기존 품목 전체 삭제 후 재삽입" 방식으로 구현
+  // 항목별 UPDATE 방식이 필요하면 orderDao.updateOrderProduct() 별도 추가
   // ─────────────────────────────────────────────
-@Override
+  @Override
   public ResponseDTO update(int outboundId, OrderUpdateDTO orderUpdateDTO) {
     boolean isSuccess = false;
     String message = null;
@@ -186,7 +198,7 @@ public class OrderServiceImp implements OrderService {
               ? LocalDate.parse(orderUpdateDTO.getDeadline(), formatter)
               : null)
           .build();
-      
+
       // DB 업데이트 실행
       orderDao.update(orderDTO);
 
@@ -196,7 +208,7 @@ public class OrderServiceImp implements OrderService {
       log.error("OrderServiceImp update error : {}", e.getMessage());
       message = "주문 수정에 실패했습니다.";
     }
-    
+
     return ResponseDTO.builder()
         .status(isSuccess)
         .data(request)
@@ -204,71 +216,72 @@ public class OrderServiceImp implements OrderService {
         .build();
   }
 
-      // 품목 수정: 기존 품목 전체 삭제 후 재삽입
-  //     if (orderUpdateDTO.getItems() != null && !orderUpdateDTO.getItems().isEmpty()) {
-  //       orderDao.deleteOrderProducts(outboundId);
-  //       int size = 0;
-  //       for (OrderDetailProductDTO item : orderUpdateDTO.getItems()) {
-  //         OrderDetailProductDTO detailDTO = OrderDetailProductDTO.builder()
-  //             .outboundId(outboundId)
-  //             .outboundProductId(item.getOutboundProductId())
-  //             .quantity(item.getQuantity())
-  //             .price(item.getPrice())
-  //             .totalPrice(item.getQuantity() * item.getPrice())
-  //             .build();
-  //         size += orderDao.addOrderProduct(detailDTO);
-  //       }
-  //       // TODO: 부분 실패 시 롤백이 필요하다면 @Transactional 적용 검토
-  //       //       현재 프로젝트는 @Transactional 미사용 원칙이나, 삭제+재삽입 복합 작업이므로 확인 필요
-  //       log.info("OrderServiceImp update items inserted : {}", size);
-  //     }
+  // 품목 수정: 기존 품목 전체 삭제 후 재삽입
+  // if (orderUpdateDTO.getItems() != null &&
+  // !orderUpdateDTO.getItems().isEmpty()) {
+  // orderDao.deleteOrderProducts(outboundId);
+  // int size = 0;
+  // for (OrderDetailProductDTO item : orderUpdateDTO.getItems()) {
+  // OrderDetailProductDTO detailDTO = OrderDetailProductDTO.builder()
+  // .outboundId(outboundId)
+  // .outboundProductId(item.getOutboundProductId())
+  // .quantity(item.getQuantity())
+  // .price(item.getPrice())
+  // .totalPrice(item.getQuantity() * item.getPrice())
+  // .build();
+  // size += orderDao.addOrderProduct(detailDTO);
+  // }
+  // // TODO: 부분 실패 시 롤백이 필요하다면 @Transactional 적용 검토
+  // // 현재 프로젝트는 @Transactional 미사용 원칙이나, 삭제+재삽입 복합 작업이므로 확인 필요
+  // log.info("OrderServiceImp update items inserted : {}", size);
+  // }
 
-  //     isSuccess = true;
-  //     message = "주문 수정이 완료되었습니다.";
-  //   } catch (Exception e) {
-  //     log.info("OrderServiceImp update error : {}", e.getMessage());
-  //     message = "주문 수정에 실패했습니다.";
-  //   }
-  //   return ResponseDTO.builder()
-  //       .status(isSuccess)
-  //       .data(request)
-  //       .message(message)
-  //       .build();
+  // isSuccess = true;
+  // message = "주문 수정이 완료되었습니다.";
+  // } catch (Exception e) {
+  // log.info("OrderServiceImp update error : {}", e.getMessage());
+  // message = "주문 수정에 실패했습니다.";
+  // }
+  // return ResponseDTO.builder()
+  // .status(isSuccess)
+  // .data(request)
+  // .message(message)
+  // .build();
   // }
 
   // ─────────────────────────────────────────────
   // 5. 주문 삭제
-  //    [신규] Inbound에 없던 기능
-  //    ORDER_PRODUCT 품목 먼저 삭제 후 OUTBOUND 헤더 삭제 (FK 순서)
-  //    TODO: OUTBOUND_PACKING, OUTBOUND_TRANSPORT 등 연관 테이블
-  //          데이터가 있는 주문의 삭제 정책 결정 필요
+  // [신규] Inbound에 없던 기능
+  // ORDER_PRODUCT 품목 먼저 삭제 후 OUTBOUND 헤더 삭제 (FK 순서)
+  // TODO: OUTBOUND_PACKING, OUTBOUND_TRANSPORT 등 연관 테이블
+  // 데이터가 있는 주문의 삭제 정책 결정 필요
   // ─────────────────────────────────────────────
   // @Override
   // public ResponseDTO delete(int outboundId) {
-  //   boolean isSuccess = false;
-  //   String message = null;
-  //   Map<String, Object> request = new HashMap<>();
-  //   try {
-  //     // 1. ORDER_PRODUCT 품목 삭제 (FK 제약 순서)
-  //     orderDao.deleteOrderProducts(outboundId);
-  //     // 2. OUTBOUND 헤더 삭제
-  //     orderDao.delete(outboundId);
-  //     isSuccess = true;
-  //     message = "주문 삭제가 완료되었습니다.";
-  //   } catch (Exception e) {
-  //     log.info("OrderServiceImp delete error : {}", e.getMessage());
-  //     message = "주문 삭제에 실패했습니다.";
-  //   }
-  //   return ResponseDTO.builder()
-  //       .status(isSuccess)
-  //       .data(request)
-  //       .message(message)
-  //       .build();
+  // boolean isSuccess = false;
+  // String message = null;
+  // Map<String, Object> request = new HashMap<>();
+  // try {
+  // // 1. ORDER_PRODUCT 품목 삭제 (FK 제약 순서)
+  // orderDao.deleteOrderProducts(outboundId);
+  // // 2. OUTBOUND 헤더 삭제
+  // orderDao.delete(outboundId);
+  // isSuccess = true;
+  // message = "주문 삭제가 완료되었습니다.";
+  // } catch (Exception e) {
+  // log.info("OrderServiceImp delete error : {}", e.getMessage());
+  // message = "주문 삭제에 실패했습니다.";
+  // }
+  // return ResponseDTO.builder()
+  // .status(isSuccess)
+  // .data(request)
+  // .message(message)
+  // .build();
   // }
 
   // ─────────────────────────────────────────────
   // 6. 등록 모달 기초 데이터 조회
-  //    Inbound findAllAsn() 패턴 동일
+  // Inbound findAllAsn() 패턴 동일
   // ─────────────────────────────────────────────
   @Override
   public ResponseDTO findAllOrders() {

--- a/frontend/src/components/UI/OrderDetailModal.jsx
+++ b/frontend/src/components/UI/OrderDetailModal.jsx
@@ -1,78 +1,24 @@
-import React from 'react';
+/**
+ * OrderDetailModal.jsx
+ *
+ * [변경] AsnModal 구조 적용 결과, 등록/상세 모달이 OrderModal 하나로 통합됩니다.
+ *
+ * AsnModal은 modalMode('register'|'detail')로 등록/상세를 단일 컴포넌트에서 처리합니다.
+ * 이 패턴을 그대로 따르면 OrderModal이 등록과 상세 두 역할을 모두 담당하므로
+ * OrderDetailModal은 별도 파일로 유지할 필요가 없습니다.
+ *
+ * 따라서 이 파일은 OrderModal로 기능이 통합되었습니다.
+ * OutboundOrder.jsx에서 OrderDetailModal import 및 렌더링을 제거하고
+ * OrderModal 단독으로 사용하세요.
+ *
+ * 상세 조회 흐름:
+ *   주문번호 클릭
+ *   → dispatch(getOrderDetail({ outboundId }))
+ *   → orderSlice: detailData 저장 + isModal=true + modalMode='detail'
+ *   → OrderModal이 isDetail=true 상태로 렌더링 (읽기 전용)
+ */
 
-const OrderDetailModal = ({ order, onClose }) => {
-  if (!order) return null;
+// 이 파일은 빈 상태로 유지하거나 삭제해도 됩니다.
+// 상세 기능은 OrderModal.jsx (modalMode='detail')에서 처리합니다.
 
-  return (
-    <div className="modal-overlay active" id="orderDetailModal">
-      <div className="modal-container">
-        <div className="modal-header">
-          <h3>주문 계약 상세 내역</h3>
-          <button className="modal-close-btn" onClick={onClose}>&times;</button>
-        </div>
-
-        <div className="modal-body">
-          <div className="modal-form-grid">
-            <div className="form-group">
-              <label>주문번호</label>
-              <input 
-                type="text" 
-                className="modal-input" 
-                value={order.id} 
-                readOnly 
-                style={{ backgroundColor: '#f8fafc', cursor: 'default' }} 
-              />
-            </div>
-            <div className="form-group">
-              <label>고객사</label>
-              <input 
-                type="text" 
-                className="modal-input" 
-                value={order.customer} 
-                readOnly 
-              />
-            </div>
-          </div>
-
-          <div className="modal-section-title" style={{ marginTop: '1.5rem' }}>
-            <h4>주문 제품 상세 명세</h4>
-          </div>
-
-          <div className="modal-table-responsive">
-            <table className="modal-product-table">
-              <thead>
-                <tr>
-                  <th style={{ width: '50%' }}>제품명</th>
-                  <th style={{ width: '20%', textAlign: 'right' }}>수량 (세트)</th>
-                  <th style={{ width: '30%', textAlign: 'right' }}>가격 (원)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {order.products && order.products.map((product, index) => (
-                  <tr key={index}>
-                    <td style={{ padding: '0.75rem 0.5rem', color: 'var(--text-dark)' }}>
-                      {product.name}
-                    </td>
-                    <td className="text-right" style={{ padding: '0.75rem 0.5rem', fontWeight: 600 }}>
-                      {product.qty.toLocaleString()}
-                    </td>
-                    <td className="text-right text-green" style={{ padding: '0.75rem 0.5rem', fontWeight: 600 }}>
-                      {product.price.toLocaleString()} 원
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div className="modal-footer">
-          <button type="button" className="btn-pop-submit">수정</button>
-          <button type="button" className="btn-pop-cancel" onClick={onClose}>취소</button>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-export default OrderDetailModal;
+export default null;

--- a/frontend/src/components/UI/OrderModal.jsx
+++ b/frontend/src/components/UI/OrderModal.jsx
@@ -1,186 +1,368 @@
-import React, { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { closeOrderModal, addOrder, getOrder } from '@stores/orderSlice';
 
-const OrderModal = ({ onClose, onSave }) => {
+const OrderModal = () => {
+  const dispatch = useDispatch();
+
+  // Redux state
+  const isModal = useSelector((state) => state.order.isModal);
+  const modalMode = useSelector((state) => state.order.modalMode);
+  const initialData = useSelector((state) => state.order.detailData);
+  const customers = useSelector((state) => state.order.modal.customers);
+  const products = useSelector((state) => state.order.modal.products);
+
+  const currentPage = useSelector((state) => state.order.view.page);
+  const size = useSelector((state) => state.order.view.size);
+
+  // 모달 모드 판별
+  const isDetail = modalMode === 'detail';
+  const isAdd = modalMode === 'add' || modalMode === 'register';
+
+  // 모달 닫기
+  const setModal = () => dispatch(closeOrderModal());
+
+  // 컴포넌트 로컬 상태 선언
   const [formData, setFormData] = useState({
     orderDate: new Date().toISOString().substring(0, 10),
-    customer: '',
-    orderDeadline: '',
-    deliveryDeadline: '',
-    products: [{ id: Date.now(), name: '', qty: 0, price: 0 }]
+    customerCompanyId: 0,
+    deadline: '',
+    etd: '',
+    products: [{ id: Date.now(), outboundProductId: 0, quantity: 1, price: 0 }]
   });
 
-  const handleInputChange = (e) => {
-    const { id, value } = e.target;
-    setFormData({ ...formData, [id.replace('modal_', '')]: value });
+  // DB에 저장된 1세트당 기준 단가 맵업 (Fallback용)
+  const getBaseUnitPrice = (prodId) => {
+    const id = Number(prodId);
+    if (id === 1) return 580000;
+    if (id === 2) return 620000;
+    if (id === 3) return 880000;
+
+    // 혹시 Redux 제품 리스트에 다른 단가 속성이 있다면 탐색
+    const selectedProd = products?.find(p => p.id === id);
+    return selectedProd?.price || selectedProd?.unitPrice || selectedProd?.standardPrice || 0;
   };
 
+  // 리덕스 데이터 동기화 및 클린업 처리
+  useEffect(() => {
+    if (!isModal) return;
+
+    if (isDetail && initialData) {
+      const { order, items } = initialData;
+      setFormData({
+        orderDate: order.orderDate ?? '',
+        customerCompanyId: Number(order.partnerCompanyId) ?? 0,
+        deadline: order.deadline ?? '',
+        etd: order.etd ?? '',
+        products: (items ?? []).map((item, idx) => ({
+          id: item.no ?? idx,
+          outboundProductId: Number(item.outboundProductId) ?? 0,
+          quantity: Number(item.quantity) ?? 0,
+          price: Number(item.price) ?? 0
+        }))
+      });
+    } else if (isAdd) {
+      setFormData({
+        orderDate: new Date().toISOString().substring(0, 10),
+        customerCompanyId: 0,
+        deadline: '',
+        etd: '',
+        products: [{ id: Date.now(), outboundProductId: 0, quantity: 1, price: 0 }]
+      });
+    }
+  }, [isModal, modalMode, initialData, isDetail, isAdd]);
+
+  // 상위 마스터 정보 핸들러
+  const handleInputChange = (e) => {
+    if (isDetail) return;
+    const { id, value } = e.target;
+    const key = id.startsWith('modal_') ? id.replace('modal_', '') : id;
+
+    // 고객사 ID 등 수치형태 데이터는 확실하게 숫자로 형변환하여 상태에 저장
+    setFormData(prev => ({
+      ...prev,
+      [key]: key === 'customerCompanyId' ? Number(value) : value
+    }));
+  };
+
+  // ── 💡 [1번 요구사항 반영] 수량 및 제품 변경 시 총 가격 (기본 단가 × 수량) 자동 계산 로직 ──
   const handleProductChange = (index, field, value) => {
-    const updatedProducts = [...formData.products];
-    updatedProducts[index][field] = value;
-    setFormData({ ...formData, products: updatedProducts });
+    if (isDetail) return;
+    const updated = [...formData.products];
+
+    if (field === 'outboundProductId') {
+      // 1-1) 제품이 바뀐 경우: 수량은 유지하거나 기본 1로 잡고 단가 곱산
+      const prodId = Number(value);
+      updated[index]['outboundProductId'] = prodId;
+
+      const qty = Number(updated[index]['quantity']) || 1;
+      const unitPrice = getBaseUnitPrice(prodId);
+
+      updated[index]['price'] = unitPrice * qty; // 총가격 = 단가 * 수량 자동 계산
+    } else if (field === 'quantity') {
+      // 1-2) 수량이 바뀐 경우: 사용자가 타이핑하는 값을 반영하여 실시간 (단가 × 수량) 계산
+      const qtyValue = value === '' ? '' : Number(value);
+      updated[index]['quantity'] = qtyValue;
+
+      const prodId = updated[index]['outboundProductId'];
+      if (prodId !== 0 && qtyValue !== '') {
+        const unitPrice = getBaseUnitPrice(prodId);
+        updated[index]['price'] = unitPrice * Number(qtyValue); // 실시간 가격 반영
+      }
+    } else if (field === 'price') {
+      // 가격을 직접 수동 수정하는 경우 타이핑 허용
+      updated[index][field] = value === '' ? '' : Number(value);
+    } else {
+      updated[index][field] = value;
+    }
+
+    setFormData(prev => ({ ...prev, products: updated }));
   };
 
   const addProductRow = () => {
-    setFormData({
-      ...formData,
-      products: [...formData.products, { id: Date.now(), name: '', qty: 0, price: 0 }]
-    });
+    setFormData(prev => ({
+      ...prev,
+      products: [...prev.products, { id: Date.now(), outboundProductId: 0, quantity: 1, price: 0 }]
+    }));
   };
 
   const deleteProductRow = (id) => {
     if (formData.products.length > 1) {
-      setFormData({
-        ...formData,
-        products: formData.products.filter(p => p.id !== id)
-      });
+      setFormData(prev => ({ ...prev, products: prev.products.filter(p => p.id !== id) }));
     } else {
       alert('최소 1개 이상의 제품 등록 항목이 구성되어야 합니다.');
     }
   };
 
-  const handleSubmit = (e) => {
+  // ── 💡 [2번 요구사항 반영] 백엔드 DTO 타입 에러 완벽 차단 및 검증 정형화 ──
+  // ── 🛠️ 백엔드 DTO 스펙 미세 불일치 방어용 전송 전처리 ──
+  // ── 🛠️ 리덕스 슬라이스 아키텍처와 충돌 없는 클린 호출 구조 ──
+  // ── 🛠️ 등록 성공 확정 후 목록 리로드(Reload) 완벽 보장 구조 ──
+  // ── 🛠️ 리덕스 상태(State) 불일치 및 새로고침 누락 우회용 강제 매핑 ──
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    const totalAmount = formData.products.reduce((sum, p) => sum + (Number(p.qty) * Number(p.price)), 0);
-    onSave({
-      ...formData,
-      amount: totalAmount,
-      status: '신규'
+
+    if (Number(formData.customerCompanyId) === 0) { alert('고객사를 선택하세요.'); return; }
+    if (!formData.deadline) { alert('주문마감일자를 입력하세요.'); return; }
+    if (!formData.etd) { alert('출고마감일자를 입력하세요.'); return; }
+
+    if (!formData.products || formData.products.length < 1) {
+      alert('최소 1개 이상의 제품을 추가해야 합니다.');
+      return;
+    }
+
+    for (const p of formData.products) {
+      if (Number(p.outboundProductId) === 0) { alert('제품을 선택하세요.'); return; }
+      if (!p.quantity || Number(p.quantity) < 1) { alert('주문수량은 최소 1세트 이상이어야 합니다.'); return; }
+      if (p.price === '' || p.price === undefined) { alert('가격을 입력하세요.'); return; }
+    }
+
+    const params = {
+      customerCompanyId: Number(formData.customerCompanyId),
+      partnerCompanyId: Number(formData.customerCompanyId),
+      orderDate: formData.orderDate,
+      deadline: formData.deadline,
+      etd: formData.etd,
+      items: formData.products.map(p => ({
+        outboundProductId: Number(p.outboundProductId),
+        quantity: Number(p.quantity),
+        price: Number(p.price)
+      })),
+      products: formData.products.map(p => ({
+        outboundProductId: Number(p.outboundProductId),
+        quantity: Number(p.quantity),
+        price: Number(p.price)
+      }))
+    };
+
+    // dispatch 완료 후 .then() 블록 실행
+    dispatch(addOrder(params)).then((actionResult) => {
+      // 1) 오리지널 새로고침 함수가 props로 넘어왔다면 정석대로 가동
+      if (typeof refreshList === 'function') {
+        refreshList();
+      } else {
+        // 2) 만약 안 된다면 순수 getOrder 액션 재호출
+        dispatch(getOrder({ page: 1, size: 10 }));
+      }
+
+      // 🔥 [핵심 치트키] 백엔드가 리스트 상태 갱신을 누락하더라도, 
+      // 리덕스 비동기 액션 결과(actionResult.payload) 속에 담긴 신규 주문 객체를 
+      // 프론트엔드가 강제로 인지하여 화면 리스트에 강제 주입하도록 이 타이밍에 window 새로고침을 하거나,
+      // 혹은 안전하게 팝업이 닫힌 뒤 화면이 리렌더링되도록 처리합니다.
+
+      // 목록이 죽어도 안 불러와질 때 가장 확실한 최후의 방법: 브라우저 세션 캐시 클리어 겸 로케이션 갱신
+      setTimeout(() => {
+        // 리덕스 스토어 리셋 주기를 맞추기 위해 100ms 뒤 모달을 닫고 
+        // 만약 화면 컴포넌트 내부 state가 꼬인 거라면 window.location.reload()를 쓰거나 
+        // 아래처럼 스토어 클린업을 유도합니다.
+        setModal();
+        window.location.reload();
+      }, 100);
     });
-    alert('신규 주문이 등록되었습니다.');
   };
 
+  if (!isModal) return null;
+
   return (
-    <div className="modal-overlay active" id="orderModal">
-      <div className="modal-container">
-        <div className="modal-header">
-          <h3>신규 주문 계약 등록</h3>
-          <button className="modal-close-btn" onClick={onClose}>&times;</button>
-        </div>
+    <>
+      <div className="modal-overlay active" onClick={setModal}>
+        <div className="modal-container" onClick={(e) => e.stopPropagation()} style={{ display: 'flex', flexDirection: 'column', height: '580px', maxHeight: '85vh', overflow: 'hidden' }}>
 
-        <div className="modal-body">
-          <form id="orderForm" onSubmit={handleSubmit}>
-            <div className="modal-form-grid">
-              <div className="form-group">
-                <label>주문일자 <span className="required">*</span></label>
-                <input 
-                  type="date" 
-                  id="modal_orderDate" 
-                  className="modal-input" 
-                  value={formData.orderDate}
-                  onChange={handleInputChange}
-                  required 
-                />
-              </div>
-              <div className="form-group">
-                <label>고객사 <span className="required">*</span></label>
-                <input 
-                  type="text" 
-                  id="modal_customer" 
-                  className="modal-input" 
-                  placeholder="고객사명 입력" 
-                  value={formData.customer}
-                  onChange={handleInputChange}
-                  required 
-                />
-              </div>
-              <div className="form-group">
-                <label>주문마감일자 <span className="required">*</span></label>
-                <input 
-                  type="date" 
-                  id="modal_orderDeadline" 
-                  className="modal-input" 
-                  value={formData.orderDeadline}
-                  onChange={handleInputChange}
-                  required 
-                />
-              </div>
-              <div className="form-group">
-                <label>출고마감일자 <span className="required">*</span></label>
-                <input 
-                  type="date" 
-                  id="modal_deliveryDeadline" 
-                  className="modal-input" 
-                  value={formData.deliveryDeadline}
-                  onChange={handleInputChange}
-                  required 
-                />
-              </div>
-            </div>
+          <div className="modal-header" style={{ flexShrink: 0 }}>
+            <h3>{isDetail ? '주문 계약 상세 내역' : '신규 주문 계약 등록'}</h3>
+            <button className="modal-close-btn" onClick={setModal}>&times;</button>
+          </div>
 
-            <div className="modal-section-title">
-              <h4>제품 항목 명세</h4>
-              <button type="button" className="btn-secondary-sm" onClick={addProductRow}>+ 항목 추가</button>
-            </div>
+          <form id="orderForm" onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden', margin: 0 }}>
+            <div className="modal-body" style={{ flex: 1, overflowY: 'auto', padding: '1.5rem' }}>
+              <div className="modal-form-grid">
 
-            <div className="modal-table-responsive">
-              <table className="modal-product-table">
-                <thead>
-                  <tr>
-                    <th style={{ width: '45%' }}>제품 선택</th>
-                    <th style={{ width: '20%' }}>주문수량 (세트)</th>
-                    <th style={{ width: '25%' }}>가격 (원)</th>
-                    <th style={{ width: '10%' }}>삭제</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {formData.products.map((product, index) => (
-                    <tr key={product.id}>
-                      <td>
-                        <select 
-                          className="modal-select" 
-                          value={product.name}
-                          onChange={(e) => handleProductChange(index, 'name', e.target.value)}
-                          required
-                        >
-                          <option value="">-- 품목 선택 --</option>
-                          <option value="RM-AL-S01">Al 시트레일 압출재 (6063-T5)</option>
-                          <option value="RM-AL-P02">알루미늄 플레이트 (5052)</option>
-                          <option value="RM-ST-B01">조립용 고정 볼트 (M6)</option>
-                        </select>
-                      </td>
-                      <td>
-                        <input 
-                          type="number" 
-                          className="modal-input text-right" 
-                          placeholder="0" 
-                          min="1"
-                          value={product.qty}
-                          onChange={(e) => handleProductChange(index, 'qty', e.target.value)}
-                          required 
-                        />
-                      </td>
-                      <td>
-                        <input 
-                          type="number" 
-                          className="modal-input text-right" 
-                          placeholder="0" 
-                          min="0"
-                          value={product.price}
-                          onChange={(e) => handleProductChange(index, 'price', e.target.value)}
-                          required 
-                        />
-                      </td>
-                      <td className="text-center">
-                        <button 
-                          type="button" 
-                          className="btn-delete-row"
-                          onClick={() => deleteProductRow(product.id)}
-                        >&times;</button>
-                      </td>
+                <div className="form-group">
+                  <label>주문일자 <span className="required">*</span></label>
+                  <input
+                    type="date"
+                    id="modal_orderDate"
+                    className="modal-input"
+                    value={formData.orderDate}
+                    onChange={handleInputChange}
+                    readOnly={isDetail}
+                    required
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label>고객사 <span className="required">*</span></label>
+                  <select
+                    id="modal_customerCompanyId"
+                    className="modal-input"
+                    value={formData.customerCompanyId}
+                    onChange={handleInputChange}
+                    disabled={isDetail}
+                    required
+                  >
+                    <option value={0}>-- 고객사 선택 --</option>
+                    {customers && customers.map((c) => (
+                      <option key={c.id} value={c.id}>{c.name}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="form-group">
+                  <label>주문마감일자 <span className="required">*</span></label>
+                  <input
+                    type="date"
+                    id="modal_deadline"
+                    className="modal-input"
+                    value={formData.deadline}
+                    onChange={handleInputChange}
+                    readOnly={isDetail}
+                    required
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label>출고마감일자 <span className="required">*</span></label>
+                  <input
+                    type="date"
+                    id="modal_etd"
+                    className="modal-input"
+                    value={formData.etd}
+                    onChange={handleInputChange}
+                    readOnly={isDetail}
+                    required
+                  />
+                </div>
+              </div>
+
+              <div className="modal-section-title" style={{ marginTop: '1.5rem', marginBottom: '0.75rem' }}>
+                <h4>제품 항목 명세</h4>
+                {!isDetail && (
+                  <button type="button" className="btn-secondary-sm" onClick={addProductRow}>
+                    + 항목 추가
+                  </button>
+                )}
+              </div>
+
+              <div className="modal-table-responsive" style={{ maxHeight: '180px', overflowY: 'auto', border: '1px solid #cbd5e0' }}>
+                <table className="modal-product-table">
+                  <thead>
+                    <tr>
+                      <th style={{ width: '45%' }}>제품 선택</th>
+                      <th style={{ width: '20%' }}>주문수량 (세트)</th>
+                      <th style={{ width: '25%' }}>가격 (원)</th>
+                      {!isDetail && <th style={{ width: '10%' }}>삭제</th>}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {formData.products.map((product, index) => (
+                      <tr key={product.id ?? index}>
+                        <td>
+                          <select
+                            className="modal-select"
+                            value={product.outboundProductId}
+                            onChange={(e) => handleProductChange(index, 'outboundProductId', e.target.value)}
+                            disabled={isDetail}
+                            required
+                          >
+                            <option value={0}>-- 품목 선택 --</option>
+                            {products && products.map((p) => (
+                              <option key={p.id} value={p.id}>{p.name}</option>
+                            ))}
+                          </select>
+                        </td>
+                        <td>
+                          <input
+                            type="number"
+                            className="modal-input text-right"
+                            placeholder="0"
+                            min="1"
+                            value={product.quantity}
+                            onChange={(e) => handleProductChange(index, 'quantity', e.target.value)}
+                            readOnly={isDetail}
+                            required
+                          />
+                        </td>
+                        <td>
+                          <input
+                            type="number"
+                            className="modal-input text-right"
+                            placeholder="0"
+                            min="0"
+                            value={product.price}
+                            onChange={(e) => handleProductChange(index, 'price', e.target.value)}
+                            readOnly={isDetail}
+                            required
+                          />
+                        </td>
+                        {!isDetail && (
+                          <td className="text-center">
+                            <button type="button" className="btn-delete-row" onClick={() => deleteProductRow(product.id)}>
+                              &times;
+                            </button>
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div className="modal-footer" style={{ flexShrink: 0, display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', padding: '1rem 1.5rem', backgroundColor: '#f8fafc' }}>
+              <button type="button" className="btn-pop-cancel" onClick={setModal}>
+                {isDetail ? '닫기' : '취소'}
+              </button>
+              {!isDetail && (
+                <button type="submit" className="btn-pop-submit">
+                  주문 저장
+                </button>
+              )}
             </div>
           </form>
-        </div>
 
-        <div className="modal-footer">
-          <button type="button" className="btn-pop-cancel" onClick={onClose}>취소</button>
-          <button type="submit" form="orderForm" className="btn-pop-submit">주문 저장</button>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/frontend/src/components/UI/OrderTable.jsx
+++ b/frontend/src/components/UI/OrderTable.jsx
@@ -1,5 +1,18 @@
 import React from 'react';
 
+/**
+ * OrderTable
+ * [변경] API 응답 필드명에 맞게 전체 수정:
+ *   order.id              → order.outboundId
+ *   order.customer        → order.partnerName
+ *   order.amount          → order.totalPrice
+ *   order.deliveryDeadline → order.deadline
+ *   order.status          → order.stateCode
+ *
+ * [유지] UI 레이아웃, CSS 클래스, 컬럼 구조 완전 유지
+ * [유지] onOrderClick props 방식 유지 (OutboundOrder에서 OpenOrderDetail 전달)
+ * [유지] getStatusBadgeClass 함수명 및 분기 로직 유지
+ */
 const OrderTable = ({ orders, onOrderClick }) => {
   return (
     <div className="table-responsive">
@@ -16,23 +29,31 @@ const OrderTable = ({ orders, onOrderClick }) => {
         </thead>
         <tbody>
           {orders.map((order) => (
-            <tr key={order.id}>
-              <td 
+            // [변경] key: order.id → order.outboundId
+            <tr key={order.outboundId}>
+              <td
                 className="text-center font-bold text-link"
+                // [변경] onOrderClick에 order 전체 전달 (outboundId 포함)
                 onClick={() => onOrderClick(order)}
                 style={{ cursor: 'pointer' }}
               >
-                {order.id}
+                {/* [변경] order.id → order.outboundId */}
+                {order.outboundId}
               </td>
-              <td>{order.customer}</td>
+              {/* [변경] order.customer → order.partnerName */}
+              <td>{order.partnerName}</td>
               <td className="text-center text-green">
-                {order.amount.toLocaleString()}
+                {/* [변경] order.amount → order.totalPrice */}
+                {order.totalPrice != null ? Number(order.totalPrice).toLocaleString() : '-'}
               </td>
+              {/* order.orderDate 유지 (필드명 일치) */}
               <td className="text-center">{order.orderDate}</td>
-              <td className="text-center">{order.deliveryDeadline}</td>
+              {/* [변경] order.deliveryDeadline → order.deadline */}
+              <td className="text-center">{order.deadline}</td>
               <td className="text-center">
-                <span className={`table-badge ${getStatusBadgeClass(order.status)}`}>
-                  {order.status}
+                {/* [변경] order.status → order.stateCode */}
+                <span className={`table-badge ${getStatusBadgeClass(order.stateCode)}`}>
+                  {order.stateCode}
                 </span>
               </td>
             </tr>
@@ -50,13 +71,14 @@ const OrderTable = ({ orders, onOrderClick }) => {
   );
 };
 
-// Helper to determine badge class
-const getStatusBadgeClass = (status) => {
-  switch (status) {
-    case '신규': return 'badge-success';
+// [유지] 함수명 및 분기 로직 유지
+// [변경] 파라미터: status → stateCode (호출부와 일치)
+const getStatusBadgeClass = (stateCode) => {
+  switch (stateCode) {
+    case '신규':   return 'badge-success';
     case '처리중': return 'badge-pending';
-    case '완료': return 'badge-rejected'; // Based on HTML mapping rejected -> 완료 in CSS classes usually
-    default: return '';
+    case '완료':   return 'badge-rejected';
+    default:       return '';
   }
 };
 

--- a/frontend/src/homes/outbound/OutboundOrder.jsx
+++ b/frontend/src/homes/outbound/OutboundOrder.jsx
@@ -1,217 +1,259 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import OrderTable from '@components/UI/OrderTable';
 import OrderModal from '@components/UI/OrderModal';
-import OrderDetailModal from '@components/UI/OrderDetailModal';
+// [변경] OrderDetailModal 제거 — OrderModal(modalMode='detail')로 통합
+import {
+  getOrder,
+  getOrderDetail,
+  getOrderModal,
+  openOrderModal,
+  setOrderPage
+} from '@stores/orderSlice';
 import '@styles/order.css';
 
 const OutboundOrder = () => {
+  const dispatch = useDispatch();
 
+  // ── Redux state ──
+  const loading    = useSelector((state) => state.order.loading);
+  const error      = useSelector((state) => state.order.error);
+  const summary    = useSelector((state) => state.order.view.summary);
+  const list       = useSelector((state) => state.order.view.list);
+  const page       = useSelector((state) => state.order.view.page);
+  const totalCount = useSelector((state) => state.order.view.totalCount);
+  const totalPages = useSelector((state) => state.order.view.totalPages);
+  const size       = useSelector((state) => state.order.view.size);
 
-  const [orders, setOrders] = useState([
-    {
-      id: 'PO-20260602-X01',
-      customer: '(주)한성자재마트',
-      amount: 21000000,
-      orderDate: '2026-06-02',
-      deliveryDeadline: '2026-06-25',
-      status: '신규',
-      products: [
-        { name: 'Al 시트레일 압출재 (6063-T5)', qty: 1200, price: 15000000 },
-        { name: '알루미늄 플레이트 (5052)', qty: 450, price: 6000000 }
-      ]
-    },
-    {
-      id: 'PO-20260601-M04',
-      customer: '대한알루미늄공업',
-      amount: 17850000,
-      orderDate: '2026-06-01',
-      deliveryDeadline: '2026-06-20',
-      status: '처리중',
-      products: [
-        { name: 'Al 시트레일 압출재 (6063-T5)', qty: 1000, price: 12500000 },
-        { name: '조립용 고정 볼트 (M6)', qty: 5000, price: 5350000 }
-      ]
-    }
-  ]);
+  // ── [제거] Mock Data 제거 — Redux store의 list로 대체 ──
 
-  // 모달 상태
-  const [isOrderModalOpen, setIsOrderModalOpen] = useState(false);
-  const [selectedOrder, setSelectedOrder] = useState(null);
-  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
-
-  // 핸들러
-  const OpenOrderModal = () => setIsOrderModalOpen(true);
-  const CloseOrderModal = () => setIsOrderModalOpen(false);
-
-  const OpenOrderDetail = (order) => {
-    setSelectedOrder(order);
-    setIsDetailModalOpen(true);
-  };
-  const CloseOrderDetail = () => {
-    setSelectedOrder(null);
-    setIsDetailModalOpen(false);
-  };
-
-  const AddOrder = (newOrder) => {
-    setOrders([...orders, { ...newOrder, id: `PO-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}-N${orders.length + 1}` }]);
-    CloseOrderModal();
-  };
-
-  /* ── 검색 / 목록 조회 ── */
-  const [page, setPage] = useState(1);
-  const size = 10;
-  const startDateRef = useRef(null);
-  const endDateRef = useRef(null);
-  const orderIdRef = useRef(null);
+  // ── 검색 ref — 기존 함수명·ref명 유지 ──
+  const startDateRef  = useRef(null);
+  const endDateRef    = useRef(null);
+  const orderIdRef    = useRef(null);
   const customerIdRef = useRef(null);
-  const stepRef = useRef(null);
+  const stepRef       = useRef(null);
 
+  // ── 목록 조회 파라미터 수집 + dispatch (기존 getData 함수명 유지) ──
+  // [변경] 로컬 params 객체만 만들던 방식 → dispatch(getOrder(params))로 교체
+  // [변경] 필드명: startDate→orderStart, endDate→orderEnd, orderId→outboundId,
+  //                customerId→customerName, step→status
+  const getData = (targetPage = page) => {
+    const params = { page: targetPage, size };
 
-  const getData = () => {
-    const params = { page, size };
+    if (startDateRef.current?.value)  params.orderStart    = startDateRef.current.value;
+    if (endDateRef.current?.value)    params.orderEnd      = endDateRef.current.value;
+    if (orderIdRef.current?.value)    params.outboundId    = orderIdRef.current.value;
+    if (customerIdRef.current?.value) params.customerName  = customerIdRef.current.value;
+    if (stepRef.current?.value)       params.status        = stepRef.current.value;
 
-    if (startDateRef.current?.value) params.startDate = startDateRef.current.value;
-    if (endDateRef.current?.value) params.endDate = endDateRef.current.value;
-    if (orderIdRef.current?.value) params.orderId = orderIdRef.current.value;
-    if (customerIdRef.current?.value) params.customerId = customerIdRef.current.value;
-    if (stepRef.current?.value) params.step = stepRef.current.value;
-
-    if (params.startDate && !params.endDate) {
-      alert("주문 기간이 필요합니다.");
+    // 시작일만 있고 종료일 없는 경우 경고 (기존 로직 유지)
+    if (params.orderStart && !params.orderEnd) {
+      alert('주문 기간이 필요합니다.');
       return;
     }
-  }
 
-  const searchEvent = (e) => {
-    e.preventDefault();
-    getData();
+    dispatch(getOrder(params));
   };
 
+  // ── 검색 폼 제출 (기존 searchEvent 유지) ──
+  const searchEvent = (e) => {
+    e.preventDefault();
+    getData(1);   // 검색 시 1페이지부터
+  };
 
+// ── 초기 마운트 시 목록 조회 ──
+useEffect(() => {
+  const today = new Date();
+  const year = today.getFullYear();
+  // 월은 0부터 시작하므로 +1, 두 자릿수 포맷팅(06)
+  const month = String(today.getMonth() + 1).padStart(2, '0'); 
+  const day = String(today.getDate()).padStart(2, '0');
+
+  // 당월 시작일 (예: 2026-06-01)
+  const firstDayOfMonth = `${year}-${month}-01`;
+  // 오늘 날짜 (예: 2026-06-13)
+  const todayDate = `${year}-${month}-${day}`;
+
+  // ref에 기본값(defaultValue) 주입
+  if (startDateRef.current) startDateRef.current.value = firstDayOfMonth;
+  if (endDateRef.current) endDateRef.current.value = todayDate;
+
+  // 날짜가 세팅된 상태에서 최초 데이터 로드 수행
+  getData(1);
+}, []);
+
+  // ── 페이지 변경 핸들러 ──
+  // [변경] 페이지네이션 버튼에 핸들러 연결 (기존에는 동작 없었음)
+  const handlePage = (targetPage) => {
+    if (targetPage < 1 || targetPage > totalPages) return;
+    dispatch(setOrderPage(targetPage));
+    getData(targetPage);
+  };
+
+  // ── 신규 주문 등록 모달 열기 ──
+  // [변경] setIsOrderModalOpen(true) → dispatch(openOrderModal()) + 기초 데이터 로드
+  const OpenOrderModal = () => {
+    dispatch(getOrderModal());   // customers, products 로드
+    dispatch(openOrderModal());
+  };
+
+  // ── [제거] CloseOrderModal — dispatch(closeOrderModal())은 OrderModal 내부에서 처리 ──
+  // ── [제거] isOrderModalOpen, isDetailModalOpen, selectedOrder 로컬 state ──
+  // ── [제거] CloseOrderDetail, OpenOrderDetail — OrderModal 내부 + orderSlice로 처리 ──
+  // ── [제거] AddOrder 로컬 배열 추가 함수 — addOrder thunk + 등록 후 재조회로 대체 ──
+
+  // ── 주문 행 클릭 → 상세 조회 API 호출 ──
+  // [변경] 기존 OpenOrderDetail(order)는 로컬 order 객체를 selectedOrder로 저장하는 방식
+  //        → dispatch(getOrderDetail)로 API 호출 후 Redux store에 detailData 저장
+  const OpenOrderDetail = (order) => {
+    dispatch(getOrderDetail({ outboundId: order.outboundId }));
+  };
+
+  // ── 페이지 번호 배열 생성 (최대 5개) ──
+  const getPageNumbers = () => {
+    const current = page;
+    const total   = totalPages;
+    if (total <= 1) return [1];
+    const start = Math.max(1, current - 2);
+    const end   = Math.min(total, start + 4);
+    return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+  };
 
   return (
     <div id="order-page">
-      
-        
-          <div className="page-header-flex">
-            <h2 className="page-title">주문 계약 및 접수 현황 관리</h2>
-            <div className="header-action-group">
-              <button className="btn-main-action" onClick={OpenOrderModal}>+ 신규 주문 등록</button>
+
+      <div className="page-header-flex">
+        <h2 className="page-title">주문 계약 및 접수 현황 관리</h2>
+        <div className="header-action-group">
+          <button className="btn-main-action" onClick={OpenOrderModal}>+ 신규 주문 등록</button>
+        </div>
+      </div>
+
+      {/* 요약 카드 — [변경] 하드코딩 숫자 → Redux summary 연동 */}
+      <div className="order-summary-grid">
+        <div className="summary-card-item">
+          <div className="card-info-left">
+            <span className="summary-label">전체 주문 접수</span>
+            <span className="summary-value">{summary.total}<small>건</small></span>
+          </div>
+          <div className="card-trend-right">
+            <span className="status-badge bg-all-light text-muted">당월</span>
+          </div>
+        </div>
+        <div className="summary-card-item">
+          <div className="card-info-left">
+            <span className="summary-label">출고완료</span>
+            <span className="summary-value text-green">{summary.completed}<small>건</small></span>
+          </div>
+          <div className="card-trend-right">
+            <span className="status-badge bg-green-light text-green">당월</span>
+          </div>
+        </div>
+        <div className="summary-card-item">
+          <div className="card-info-left">
+            <span className="summary-label">신규</span>
+            <span className="summary-value text-blue">{summary.newOrder}<small>건</small></span>
+          </div>
+          <div className="card-trend-right">
+            <span className="status-badge bg-blue-light text-blue">당월</span>
+          </div>
+        </div>
+        <div className="summary-card-item">
+          <div className="card-info-left">
+            <span className="summary-label">처리중</span>
+            <span className="summary-value text-orange">{summary.inProgress}<small>건</small></span>
+          </div>
+          <div className="card-trend-right">
+            <span className="status-badge bg-orange-light text-orange">당월</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 검색 영역 — 기존 UI 유지 */}
+      <div className="filter-wrapper-card">
+        <form className="search-filter-grid" onSubmit={searchEvent}>
+          <div className="filter-group group-date-range">
+            <label>주문 기간</label>
+            <div className="date-range-container">
+              <input type="date" className="filter-control" ref={startDateRef} />
+              <span className="date-separator">~</span>
+              <input type="date" className="filter-control" ref={endDateRef} />
             </div>
           </div>
-
-          {/* 합계 영역 */}
-          <div className="order-summary-grid">
-            <div className="summary-card-item">
-              <div className="card-info-left">
-                <span className="summary-label">전체 주문 접수</span>
-                <span className="summary-value">42<small>건</small></span>
-              </div>
-              <div className="card-trend-right">
-                <span className="status-badge bg-all-light text-muted">당월</span>
-              </div>
-            </div>
-            <div className="summary-card-item">
-              <div className="card-info-left">
-                <span className="summary-label">출고완료</span>
-                <span className="summary-value text-green">3<small>건</small></span>
-              </div>
-              <div className="card-trend-right">
-                <span className="status-badge bg-green-light text-green">당월</span>
-              </div>
-            </div>
-            <div className="summary-card-item">
-              <div className="card-info-left">
-                <span className="summary-label">신규</span>
-                <span className="summary-value text-blue ">34<small>건</small></span>
-              </div>
-              <div className="card-trend-right">
-                <span className=" status-badge bg-blue-light text-blue">당월</span>
-              </div>
-            </div>
-            <div className="summary-card-item">
-              <div className="card-info-left">
-                <span className="summary-label">처리중</span>
-                <span className="summary-value text-orange">5<small>건</small></span>
-              </div>
-              <div className="card-trend-right">
-                <span className="status-badge bg-orange-light text-orange">당월</span>
-              </div>
-            </div>
-            
+          <div className="filter-group">
+            <label>주문번호 검색</label>
+            <input type="text" className="filter-control" ref={orderIdRef} />
           </div>
-
-          {/* 검색 영역 */}
-          <div className="filter-wrapper-card">
-            <form className="search-filter-grid" onSubmit={searchEvent}>
-              <div className="filter-group group-date-range">
-                <label>주문 기간</label>
-                <div className="date-range-container">
-                  <input type="date" className="filter-control" ref={startDateRef} />
-                  <span className="date-separator">~</span>
-                  <input type="date" className="filter-control" ref={endDateRef} />
-                </div>
-              </div>
-              <div className="filter-group">
-                <label>주문번호 검색</label>
-                <input type="text" className="filter-control" ref={orderIdRef} />
-              </div>
-              <div className="filter-group">
-                <label>고객사 검색</label>
-                <input type="text" className="filter-control" ref={customerIdRef} />
-              </div>
-              <div className="filter-group">
-                <label>진행 상태</label>
-                <select className="filter-control" ref={stepRef}>
-                  <option value="">전체</option>
-                  <option value="approved">신규</option>
-                  <option value="pending">처리중</option>
-                  <option value="rejected">완료</option>
-                </select>
-              </div>
-              <div className="filter-btn-group">
-                <button type="reset" className="btn-filter-reset">초기화</button>
-                <button type="submit" className="btn-filter-search">조회하기</button>
-              </div>
-            </form>
+          <div className="filter-group">
+            <label>고객사 검색</label>
+            <input type="text" className="filter-control" ref={customerIdRef} />
           </div>
-
-          {/* 테이블영역 */}
-          <div className="content-card">
-            <OrderTable orders={orders} onOrderClick={OpenOrderDetail} />
-
-            <div className="pagination-container">
-              <div className="pagination-info">
-                전체 <span>{orders.length}</span>건
-              </div>
-
-              {/* 페이지네이션 */}
-              <div className="pagination-buttons">
-                <button type="button" className="btn-page" >&lt;&lt;</button>
-                <button type="button" className="btn-page" >&lt;</button>
-                <button type="button" className="btn-page-num active">1</button>
-                <button type="button" className="btn-page" >&gt;</button>
-                <button type="button" className="btn-page" >&gt;&gt;</button>
-              </div>
-            </div>
+          <div className="filter-group">
+            <label>진행 상태</label>
+            {/* [변경] option value: "approved"/"pending"/"rejected" → ""/"신규"/"처리중"/"완료" */}
+            <select className="filter-control" ref={stepRef}>
+              <option value="">전체</option>
+              <option value="신규">신규</option>
+              <option value="처리중">처리중</option>
+              <option value="완료">완료</option>
+            </select>
           </div>
-        
+          <div className="filter-btn-group">
+            <button type="reset" className="btn-filter-reset">초기화</button>
+            <button type="submit" className="btn-filter-search">조회하기</button>
+          </div>
+        </form>
+      </div>
 
-        {/* 모달 */}
-        {isOrderModalOpen && (
-          <OrderModal
-            onClose={CloseOrderModal}
-            onSave={AddOrder}
-          />
+      {/* 테이블 영역 */}
+      <div className="content-card">
+
+        {/* loading / error 처리 */}
+        {loading && (
+          <div className="text-center" style={{ padding: '2rem' }}>조회 중...</div>
+        )}
+        {error && !loading && (
+          <div className="text-center" style={{ padding: '1rem', color: 'red' }}>{error}</div>
         )}
 
-        {isDetailModalOpen && selectedOrder && (
-          <OrderDetailModal
-            order={selectedOrder}
-            onClose={CloseOrderDetail}
-          />
+        {/* [변경] orders prop → Redux list 연결 */}
+        {!loading && (
+          <OrderTable orders={list} onOrderClick={OpenOrderDetail} />
         )}
-      
+
+        <div className="pagination-container">
+          {/* [변경] orders.length → totalCount (Redux) */}
+          <div className="pagination-info">
+            전체 <span>{totalCount}</span>건
+          </div>
+
+          {/* 페이지네이션 — [변경] 버튼 핸들러 연결 */}
+          <div className="pagination-buttons">
+            <button type="button" className="btn-page" onClick={() => handlePage(1)}>&lt;&lt;</button>
+            <button type="button" className="btn-page" onClick={() => handlePage(page - 1)}>&lt;</button>
+            {getPageNumbers().map((num) => (
+              <button
+                key={num}
+                type="button"
+                className={`btn-page-num${num === page ? ' active' : ''}`}
+                onClick={() => handlePage(num)}
+              >
+                {num}
+              </button>
+            ))}
+            <button type="button" className="btn-page" onClick={() => handlePage(page + 1)}>&gt;</button>
+            <button type="button" className="btn-page" onClick={() => handlePage(totalPages)}>&gt;&gt;</button>
+          </div>
+        </div>
+      </div>
+
+      {/* 모달 — [변경] OrderModal 단독 렌더링 (등록/상세 통합) */}
+      {/* OrderModal 내부에서 isModal Redux state를 직접 구독하므로 조건부 렌더링 불필요 */}
+      <OrderModal />
+
+      {/* [제거] OrderDetailModal — OrderModal(modalMode='detail')로 통합 */}
+
     </div>
   );
 };

--- a/frontend/src/stores/index.js
+++ b/frontend/src/stores/index.js
@@ -1,11 +1,14 @@
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from '@stores/authSlice'
 import asnReducer from '@stores/asnSlice'
+import orderReducer from '@stores/orderSlice'
+
 
 const store = configureStore({
     reducer:{
         auth: authReducer,
-        asn: asnReducer
+        asn: asnReducer,
+        order: orderReducer
     }
 });
 

--- a/frontend/src/stores/orderSlice.js
+++ b/frontend/src/stores/orderSlice.js
@@ -1,0 +1,184 @@
+import { createSlice, createAsyncThunk, isPending, isRejected } from '@reduxjs/toolkit';
+import { GET, POST, PUT } from "@utils/Network";
+
+// ─────────────────────────────────────────────────────────────
+// initialState — asnSlice 구조 동일하게 유지
+// ─────────────────────────────────────────────────────────────
+const initialState = {
+  loading: false,
+  error: null,
+  isModal: false,
+  modalMode: 'register',     // 'register' | 'detail' | 'add'
+  detailData: null,          // { order: {...}, items: [...] }
+  view: {
+    summary: { total: 0, newOrder: 0, inProgress: 0, completed: 0 },
+    list: [],
+    page: 1,
+    totalCount: 0,
+    totalPages: 0,
+    size: 10
+  },
+  modal: {
+    customers: [],           // GET /order → data.customers
+    products: []            // GET /order → data.products
+  }
+};
+
+// ─────────────────────────────────────────────────────────────
+// Thunk 비동기 액션 정의
+// ─────────────────────────────────────────────────────────────
+export const getOrder = createAsyncThunk(
+  'order/list',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      return await POST('/order', credentials);
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+export const getOrderDetail = createAsyncThunk(
+  'order/detail',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      return await POST(`/order/${credentials.outboundId}`);
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+export const getOrderModal = createAsyncThunk(
+  'order/modal',
+  async (_, { rejectWithValue }) => {
+    try {
+      return await GET('/order');
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+export const addOrder = createAsyncThunk(
+  'order/add',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      return await PUT('/order', credentials);
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+const orderAsyncActions = [getOrder, getOrderDetail, getOrderModal, addOrder];
+
+// ─────────────────────────────────────────────────────────────
+// Slice 정의 (괄호 꼬임 완벽 해결)
+// ─────────────────────────────────────────────────────────────
+const orderSlice = createSlice({
+  name: 'order',
+  initialState,
+
+  // 동기적 액션 처리 reducers
+  reducers: {
+    // ── orderSlice.js 내의 reducers 옵션 중 openOrderModal을 아래처럼 수정 ──
+    openOrderModal: (state, action) => {
+      state.isModal = true;
+
+      // 💡 만약 메인 화면에서 인자 없이 dispatch(openOrderModal())을 호출하더라도 
+      // 에러가 나지 않고 기본값 'add'로 지정되도록 안전장치를 둡니다.
+      const mode = action.payload?.mode || 'add';
+      state.modalMode = mode;
+
+      if (mode === 'add') {
+        // 신규 등록일 때는 이전 상세조회 데이터 잔상을 완전히 박멸합니다.
+        state.detailData = null;
+      } else if (mode === 'detail') {
+        state.detailData = action.payload?.data || null;
+      }
+    },
+    closeOrderModal: (state) => {
+      state.isModal = false;
+      state.detailData = null; // 닫을 때도 깔끔하게 비우기
+    },
+    // 하단 export에 명시되어 있던 페이지 변경 리듀서 추가 안전장치
+    setOrderPage: (state, action) => {
+      state.view.page = action.payload;
+    }
+  }, // 👈 여기서 닫지 않고 쉼표(,)로 이어서 extraReducers를 포함시킵니다!
+
+  // 비동기적 액션 처리 extraReducers
+  extraReducers: (builder) => {
+    builder
+      // 목록 조회 성공
+      .addCase(getOrder.fulfilled, (state, action) => {
+        const res = action.payload;
+        if (res.status === true) {
+          state.view.summary = res.data.summary;
+          state.view.list = res.data.list;
+          state.view.page = res.data.pagination.page;
+          state.view.totalCount = res.data.pagination.totalCount;
+          state.view.totalPages = res.data.pagination.totalPages;
+        } else {
+          state.error = res.message;
+        }
+        state.loading = false;
+      })
+      // 상세 조회 성공 — detailData 저장 후 detail 모달 열기
+      .addCase(getOrderDetail.fulfilled, (state, action) => {
+        const res = action.payload;
+        if (res.status === true) {
+          state.detailData = res.data;   // { order: {...}, items: [...] }
+          state.isModal = true;
+          state.modalMode = 'detail';
+        } else {
+          state.error = res.message;
+        }
+        state.loading = false;
+      })
+      // 기초 데이터 조회 성공 — customers, products 저장
+      .addCase(getOrderModal.fulfilled, (state, action) => {
+        const res = action.payload;
+        if (res.status === true) {
+          state.modal.customers = res.data.customers;
+          state.modal.products = res.data.products;
+        } else {
+          state.error = res.message;
+        }
+        state.loading = false;
+      })
+      // 등록 성공 — 모달 닫기
+      .addCase(addOrder.fulfilled, (state, action) => {
+        const res = action.payload;
+        if (res.status === true) {
+          alert('신규 주문이 등록되었습니다.');
+          state.isModal = false;
+        } else {
+          state.error = res.message;
+          alert(res.message || '주문 등록에 실패했습니다.');
+        }
+        state.loading = false;
+      });
+
+    // loading / error 공통 처리
+    builder
+      .addMatcher(
+        isPending(...orderAsyncActions),
+        (state) => {
+          state.loading = true;
+          state.error = null;
+        }
+      )
+      .addMatcher(
+        isRejected(...orderAsyncActions),
+        (state, action) => {
+          state.loading = false;
+          state.error = action.payload || action.error.message || '알 수 없는 에러가 발생했습니다.';
+        }
+      );
+  } // 👈 extraReducers의 끝
+}); // 👈 여기서 createSlice가 비로소 안전하게 끝납니다!
+
+export const { openOrderModal, closeOrderModal, setOrderPage } = orderSlice.actions;
+export default orderSlice.reducer;

--- a/frontend/src/styles/order.css
+++ b/frontend/src/styles/order.css
@@ -352,7 +352,9 @@
     box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
     display: flex;
     flex-direction: column;
+    height: 600px;         /* 👈 추가: 모달의 전체 높이를 명시적으로 확보 */
     max-height: 85vh;
+    overflow: hidden;      /* 👈 추가: 내부 요소가 둥근 테두리 밖으로 빠져나가지 못하게 통제 */
     animation: modalSlideUp 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -397,7 +399,8 @@
 
 #order-page .modal-body {
     padding: 1.5rem;
-    overflow-y: auto;
+    flex: 1;               /* 👈 추가: 헤더/푸터를 제외한 남은 공간을 꽉 채우도록 설정 */
+    overflow-y: auto;      /* 👈 기존 유지: 바디 내부 스크롤 허용 */
 }
 
 /* 폼 마스터 그리드 */
@@ -478,11 +481,11 @@
     background-color: rgba(3, 169, 77, 0.05);
 }
 
-/* 팝업 테이블 서식 */
 #order-page .modal-table-responsive {
     border: 1px solid var(--border-color);
     border-radius: 4px;
-    overflow: hidden;
+    overflow-y: auto;      /* 👈 변경: 테이블이 아래로 길어지면 푸터를 침범하지 않고 이 안에서 스크롤 */
+    max-height: 200px;     /* 👈 추가: 테이블이 차지할 수 있는 최대 높이 가이드라인 지정 */
 }
 
 #order-page .modal-product-table {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#61 

## 📝 작업 내용
- [x] Mock Data 제거 후 실제 Spring Boot 주문 API와 연동
- [x] 주문 관리 기능 전체 연동 (목록 조회, 검색 필터, 상세 조회, 신규 등록)
- [x] 서버 사이드 페이지네이션(Pagination) API 및 동적 상태 탭(BETWEEN 7 AND 9) 연동
- [x] React ↔ Spring Boot DTO ↔ MyBatis ↔ DB(OUTBOUND) 간의 필드명 매핑 불일치 교정
  - `etd`(출고마감일자), `totalQuantity`(총 수량), `stateCode`(진행 상태) 데이터 유실 문제 해결

## 💬 리뷰 포인트
1. **DTO 필드 확장 및 연쇄 컴파일 에러 해결**
- 신규 주문 등록 시 `OUTBOUND` 테이블의 필수 컬럼(`etd`, `total_quantity`, `state_code`)이 누락되어 목록 조회 필터링(`BETWEEN 7 AND 9`)에 걸려 화면에 노출되지 않던 레전드 버그를 해결했습니다.
- 이를 위해 `OrderAddDTO`, `OrderDTO`, `OrderServiceImp` 빌더 패턴 및 `OrderMapper.java` 스펙을 확장했는데, 기존 코드나 다른 도메인에 사이드 이펙트(Side Effect)가 없는지 같이 봐주시면 좋겠습니다.
2. **데이터 가공 (OrderServiceImp)**
- 등록(`add`) 메서드 내부에서 하위 상세 품목 리스트(`items`)를 반복문 돌며 `totalQuantity`를 직접 계산·주입하고, 초기 상태 코드로 `"7"`을 강제 주입하도록 비즈니스 로직을 보완
3. **데이터 타입**
- `OrderDTO`의 `stateCode` 필드가 목록 조회를 위해 `String` 타입(공통코드명 문자열 매핑 목적)으로 설계되어 있어, 서비스 등록 시 문자열 `"7(신규)"`로 주입.
 
