### PR TITLE
출고 - 패킹 완료처리 api / 완료 전용 페이지 추가

### DIFF
--- a/backend/src/main/java/cloud/weareithero/api/packing/PackingController.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/PackingController.java
@@ -41,7 +41,7 @@ public class PackingController implements PackingControllerDocs {
 
     @PatchMapping("/{invoiceId:[A-Za-z0-9-]+}")
     @Override
-    public ResponseDTO completePacking(@PathVariable String invoiceId) {
-        return packingService.completePacking(invoiceId);
+    public ResponseDTO completePacking(@PathVariable String packingInvoiceNumber) {
+        return packingService.completePacking(packingInvoiceNumber);
     }
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/PackingController.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/PackingController.java
@@ -1,5 +1,6 @@
 package cloud.weareithero.api.packing;
 
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,7 +29,7 @@ public class PackingController implements PackingControllerDocs {
 
     @PostMapping("/{orderId:[0-9]+}")
     @Override
-    public ResponseDTO findOne(@PathVariable Integer orderId) {
+    public ResponseDTO findOne(@PathVariable int orderId) {
         return packingService.findOne(orderId);
     }
     
@@ -38,4 +39,9 @@ public class PackingController implements PackingControllerDocs {
         return packingService.addPacking(packingAddDTO);
     }
 
+    @PatchMapping("/{invoiceId:[0-9]+}")
+    @Override
+    public ResponseDTO completePacking(@PathVariable int invoiceId) {
+        return packingService.completePacking(invoiceId);
+    }
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/PackingController.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/PackingController.java
@@ -39,7 +39,7 @@ public class PackingController implements PackingControllerDocs {
         return packingService.addPacking(packingAddDTO);
     }
 
-    @PatchMapping("/{invoiceId:[A-Za-z0-9-]+}")
+    @PatchMapping("/{packingInvoiceNumber:[A-Za-z0-9-]+}")
     @Override
     public ResponseDTO completePacking(@PathVariable String packingInvoiceNumber) {
         return packingService.completePacking(packingInvoiceNumber);

--- a/backend/src/main/java/cloud/weareithero/api/packing/PackingController.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/PackingController.java
@@ -39,9 +39,9 @@ public class PackingController implements PackingControllerDocs {
         return packingService.addPacking(packingAddDTO);
     }
 
-    @PatchMapping("/{invoiceId:[0-9]+}")
+    @PatchMapping("/{invoiceId:[A-Za-z0-9-]+}")
     @Override
-    public ResponseDTO completePacking(@PathVariable int invoiceId) {
+    public ResponseDTO completePacking(@PathVariable String invoiceId) {
         return packingService.completePacking(invoiceId);
     }
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/PackingControllerDocs.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/PackingControllerDocs.java
@@ -45,6 +45,6 @@ public interface PackingControllerDocs {
     @Operation(summary = "Packing 완료 처리", description = "Packing API")
     @ApiCommonSuccess
     @ApiCommonErrors
-    public ResponseDTO completePacking(int invoiceId);
+    public ResponseDTO completePacking(String invoiceId);
     
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/PackingControllerDocs.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/PackingControllerDocs.java
@@ -30,7 +30,7 @@ public interface PackingControllerDocs {
     @Operation(summary = "Packing 상세 조회", description = "Packing API")
     @ApiCommonSuccess
     @ApiCommonErrors
-    public ResponseDTO findOne(Integer packingId);
+    public ResponseDTO findOne(int packingId);
 
     @Operation(summary = "Packing 생성", description = "Packing API")
     @ApiCommonSuccess
@@ -41,5 +41,10 @@ public interface PackingControllerDocs {
         }
     )) 
     PackingAddDTO packingAddDTO);
+
+    @Operation(summary = "Packing 완료 처리", description = "Packing API")
+    @ApiCommonSuccess
+    @ApiCommonErrors
+    public ResponseDTO completePacking(int invoiceId);
     
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/PackingControllerDocs.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/PackingControllerDocs.java
@@ -45,6 +45,6 @@ public interface PackingControllerDocs {
     @Operation(summary = "Packing 완료 처리", description = "Packing API")
     @ApiCommonSuccess
     @ApiCommonErrors
-    public ResponseDTO completePacking(String invoiceId);
+    public ResponseDTO completePacking(String packingInvoiceNumber);
     
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDao.java
@@ -18,5 +18,10 @@ public interface PackingDao {
     List<PackingInvoiceDTO> findInvoice(int orderId);
     public int updateStateCode(int orderId);
     public int addInvoice(PackingInvoiceDTO packingInvoiceDTO);
+    public int findPackingInvoiceStateCode(int invoiceId);
+    public int updatePackingInvoiceStateCode(int invoiceId);
+    public int countNotCompleted(int orderId);
+    public int updateOrderStateCode(int orderId);
+    public int findOrderIdByInvoiceId(int invoiceId);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDao.java
@@ -18,10 +18,10 @@ public interface PackingDao {
     List<PackingInvoiceDTO> findInvoice(int orderId);
     public int updateStateCode(int orderId);
     public int addInvoice(PackingInvoiceDTO packingInvoiceDTO);
-    public int findPackingInvoiceStateCode(int invoiceId);
-    public int updatePackingInvoiceStateCode(int invoiceId);
+    public int findPackingInvoiceStateCode(String invoiceId);
+    public int updatePackingInvoiceStateCode(String invoiceId);
     public int countNotCompleted(int orderId);
     public int updateOrderStateCode(int orderId);
-    public int findOrderIdByInvoiceId(int invoiceId);
+    public int findOrderIdByInvoiceId(String invoiceId);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDao.java
@@ -18,10 +18,10 @@ public interface PackingDao {
     List<PackingInvoiceDTO> findInvoice(int orderId);
     public int updateStateCode(int orderId);
     public int addInvoice(PackingInvoiceDTO packingInvoiceDTO);
-    public int findPackingInvoiceStateCode(String invoiceId);
-    public int updatePackingInvoiceStateCode(String invoiceId);
+    public int findPackingInvoiceStateCode(String packingInvoiceNumber);
+    public int updatePackingInvoiceStateCode(String packingInvoiceNumber);
     public int countNotCompleted(int orderId);
     public int updateOrderStateCode(int orderId);
-    public int findOrderIdByInvoiceId(String invoiceId);
+    public int findOrderIdByInvoiceId(String packingInvoiceNumber);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDaoImp.java
@@ -59,12 +59,12 @@ public class PackingDaoImp implements PackingDao {
     }
 
     @Override
-    public int findPackingInvoiceStateCode(int invoiceId) {
+    public int findPackingInvoiceStateCode(String invoiceId) {
         return packingMapper.findPackingInvoiceStateCode(invoiceId);
     }
 
     @Override
-    public int updatePackingInvoiceStateCode(int invoiceId) {
+    public int updatePackingInvoiceStateCode(String invoiceId) {
         return packingMapper.updatePackingInvoiceStateCode(invoiceId);
     }
 
@@ -79,7 +79,7 @@ public class PackingDaoImp implements PackingDao {
     }
 
     @Override
-    public int findOrderIdByInvoiceId(int invoiceId) {
+    public int findOrderIdByInvoiceId(String invoiceId) {
         return packingMapper.findOrderIdByInvoiceId(invoiceId);
     }
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDaoImp.java
@@ -57,4 +57,29 @@ public class PackingDaoImp implements PackingDao {
     public int addInvoice(PackingInvoiceDTO packingInvoiceDTO) {
         return packingMapper.addInvoice(packingInvoiceDTO);
     }
+
+    @Override
+    public int findPackingInvoiceStateCode(int invoiceId) {
+        return packingMapper.findPackingInvoiceStateCode(invoiceId);
+    }
+
+    @Override
+    public int updatePackingInvoiceStateCode(int invoiceId) {
+        return packingMapper.updatePackingInvoiceStateCode(invoiceId);
+    }
+
+    @Override
+    public int countNotCompleted(int orderId) {
+        return packingMapper.countNotCompleted(orderId);
+    }
+
+    @Override
+    public int updateOrderStateCode(int orderId) {
+        return packingMapper.updateOrderStateCode(orderId);
+    }
+
+    @Override
+    public int findOrderIdByInvoiceId(int invoiceId) {
+        return packingMapper.findOrderIdByInvoiceId(invoiceId);
+    }
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingDaoImp.java
@@ -59,13 +59,13 @@ public class PackingDaoImp implements PackingDao {
     }
 
     @Override
-    public int findPackingInvoiceStateCode(String invoiceId) {
-        return packingMapper.findPackingInvoiceStateCode(invoiceId);
+    public int findPackingInvoiceStateCode(String packingInvoiceNumber) {
+        return packingMapper.findPackingInvoiceStateCode(packingInvoiceNumber);
     }
 
     @Override
-    public int updatePackingInvoiceStateCode(String invoiceId) {
-        return packingMapper.updatePackingInvoiceStateCode(invoiceId);
+    public int updatePackingInvoiceStateCode(String packingInvoiceNumber) {
+        return packingMapper.updatePackingInvoiceStateCode(packingInvoiceNumber);
     }
 
     @Override
@@ -79,7 +79,7 @@ public class PackingDaoImp implements PackingDao {
     }
 
     @Override
-    public int findOrderIdByInvoiceId(String invoiceId) {
-        return packingMapper.findOrderIdByInvoiceId(invoiceId);
+    public int findOrderIdByInvoiceId(String packingInvoiceNumber) {
+        return packingMapper.findOrderIdByInvoiceId(packingInvoiceNumber);
     }
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingMapper.java
@@ -164,11 +164,11 @@ public interface PackingMapper {
     
     // 패킹 송장 단건 조회 (이미 완료된 건지 확인용)
     @Select("SELECT `state_code` FROM `OUTBOUND_PACKING` WHERE `id` = #{invoiceId}")
-    public int findPackingInvoiceStateCode(int invoiceId);
+    public int findPackingInvoiceStateCode(String invoiceId);
     
     // 패킹 송장 state_code 20(패킹완료)으로 업데이트
     @Update("UPDATE `OUTBOUND_PACKING` SET `state_code` = 20 WHERE `id` = #{invoiceId}")
-    public int updatePackingInvoiceStateCode(int invoiceId);
+    public int updatePackingInvoiceStateCode(String invoiceId);
 
     // 해당 주문의 전체 패킹 송장 중 20(패킹완료)이 아닌 것이 있는지 확인
     @Select("SELECT COUNT(*) FROM `OUTBOUND_PACKING` WHERE `outbound_id` = #{orderId} AND `state_code` != 20")
@@ -180,7 +180,7 @@ public interface PackingMapper {
 
     // 패킹 송장으로 outbound_id(주문번호) 조회
     @Select("SELECT `outbound_id` FROM `OUTBOUND_PACKING` WHERE `id` = #{invoiceId}")
-    public int findOrderIdByInvoiceId(int invoiceId);
+    public int findOrderIdByInvoiceId(String invoiceId);
 
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingMapper.java
@@ -163,7 +163,7 @@ public interface PackingMapper {
     public int addInvoice(PackingInvoiceDTO packingInvoiceDTO);
     
     // 패킹 송장 단건 조회 (이미 완료된 건지 확인용)
-    @Select("SELECT `state_code` FROM `OUTBOUND_PACKING` WHERE `packing_invoice_nubmer` = #{packingInvoiceNumber}")
+    @Select("SELECT `state_code` FROM `OUTBOUND_PACKING` WHERE `packing_invoice_number` = #{packingInvoiceNumber}")
     public int findPackingInvoiceStateCode(String packingInvoiceNumber);
     
     // 패킹 송장 state_code 20(패킹완료)으로 업데이트

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingMapper.java
@@ -163,12 +163,12 @@ public interface PackingMapper {
     public int addInvoice(PackingInvoiceDTO packingInvoiceDTO);
     
     // 패킹 송장 단건 조회 (이미 완료된 건지 확인용)
-    @Select("SELECT `state_code` FROM `OUTBOUND_PACKING` WHERE `id` = #{invoiceId}")
-    public int findPackingInvoiceStateCode(String invoiceId);
+    @Select("SELECT `state_code` FROM `OUTBOUND_PACKING` WHERE `packing_invoice_nubmer` = #{packingInvoiceNumber}")
+    public int findPackingInvoiceStateCode(String packingInvoiceNumber);
     
     // 패킹 송장 state_code 20(패킹완료)으로 업데이트
-    @Update("UPDATE `OUTBOUND_PACKING` SET `state_code` = 20 WHERE `id` = #{invoiceId}")
-    public int updatePackingInvoiceStateCode(String invoiceId);
+    @Update("UPDATE `OUTBOUND_PACKING` SET `state_code` = 20 WHERE `packing_invoice_number` = #{packingInvoiceNumber}")
+    public int updatePackingInvoiceStateCode(String packingInvoiceNumber);
 
     // 해당 주문의 전체 패킹 송장 중 20(패킹완료)이 아닌 것이 있는지 확인
     @Select("SELECT COUNT(*) FROM `OUTBOUND_PACKING` WHERE `outbound_id` = #{orderId} AND `state_code` != 20")
@@ -179,8 +179,8 @@ public interface PackingMapper {
     public int updateOrderStateCode(int orderId);
 
     // 패킹 송장으로 outbound_id(주문번호) 조회
-    @Select("SELECT `outbound_id` FROM `OUTBOUND_PACKING` WHERE `id` = #{invoiceId}")
-    public int findOrderIdByInvoiceId(String invoiceId);
+    @Select("SELECT `outbound_id` FROM `OUTBOUND_PACKING` WHERE `packing_invoice_number` = #{packingInvoiceNumber}")
+    public int findOrderIdByInvoiceId(String packingInvoiceNumber);
 
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/dao/PackingMapper.java
@@ -161,5 +161,26 @@ public interface PackingMapper {
             VALUES (#{orderId}, #{packingInvoiceNumber}, #{productId}, #{carrierId}, 19)
             """)
     public int addInvoice(PackingInvoiceDTO packingInvoiceDTO);
+    
+    // 패킹 송장 단건 조회 (이미 완료된 건지 확인용)
+    @Select("SELECT `state_code` FROM `OUTBOUND_PACKING` WHERE `id` = #{invoiceId}")
+    public int findPackingInvoiceStateCode(int invoiceId);
+    
+    // 패킹 송장 state_code 20(패킹완료)으로 업데이트
+    @Update("UPDATE `OUTBOUND_PACKING` SET `state_code` = 20 WHERE `id` = #{invoiceId}")
+    public int updatePackingInvoiceStateCode(int invoiceId);
+
+    // 해당 주문의 전체 패킹 송장 중 20(패킹완료)이 아닌 것이 있는지 확인
+    @Select("SELECT COUNT(*) FROM `OUTBOUND_PACKING` WHERE `outbound_id` = #{orderId} AND `state_code` != 20")
+    public int countNotCompleted(int orderId);
+
+    // OUTBOUND(주문) state_code 20(패킹완료)으로 업데이트
+    @Update("UPDATE `OUTBOUND` SET `state_code` = 20 WHERE `id` = #{orderId}")
+    public int updateOrderStateCode(int orderId);
+
+    // 패킹 송장으로 outbound_id(주문번호) 조회
+    @Select("SELECT `outbound_id` FROM `OUTBOUND_PACKING` WHERE `id` = #{invoiceId}")
+    public int findOrderIdByInvoiceId(int invoiceId);
+
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/service/PackingService.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/service/PackingService.java
@@ -12,5 +12,5 @@ public interface PackingService {
 
     public ResponseDTO addPacking(PackingAddDTO PackingAddDTO);
 
-    public ResponseDTO completePacking(int invoiceId);
+    public ResponseDTO completePacking(String invoiceId);
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/service/PackingService.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/service/PackingService.java
@@ -12,5 +12,5 @@ public interface PackingService {
 
     public ResponseDTO addPacking(PackingAddDTO PackingAddDTO);
 
-    public ResponseDTO completePacking(String invoiceId);
+    public ResponseDTO completePacking(String packingInvoiceNumber);
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/service/PackingService.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/service/PackingService.java
@@ -11,4 +11,6 @@ public interface PackingService {
     public ResponseDTO findOne(int orderId);
 
     public ResponseDTO addPacking(PackingAddDTO PackingAddDTO);
+
+    public ResponseDTO completePacking(int invoiceId);
 }

--- a/backend/src/main/java/cloud/weareithero/api/packing/service/PackingServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/service/PackingServiceImp.java
@@ -126,12 +126,12 @@ public class PackingServiceImp implements PackingService {
 
     @Transactional
     @Override
-    public ResponseDTO completePacking(String invoiceId) {
+    public ResponseDTO completePacking(String packingInvoiceNumber) {
         boolean isSuccess = false;
         String message = null;
         try {
             // 1. 이미 완료된 패킹 송장인지 확인
-            int stateCode = packingDao.findPackingInvoiceStateCode(invoiceId);
+            int stateCode = packingDao.findPackingInvoiceStateCode(packingInvoiceNumber);
             if (stateCode == 20) {
                 message = "이미 패킹완료 처리된 송장입니다.";
                 return ResponseDTO.builder()
@@ -141,10 +141,10 @@ public class PackingServiceImp implements PackingService {
             }
 
             // 2. 패킹 송장 state_code 20(패킹완료)으로 변경
-            packingDao.updatePackingInvoiceStateCode(invoiceId);
+            packingDao.updatePackingInvoiceStateCode(packingInvoiceNumber);
 
             // 3. 해당 주문의 전체 송장이 완료됐는지 확인
-            int orderId = packingDao.findOrderIdByInvoiceId(invoiceId);
+            int orderId = packingDao.findOrderIdByInvoiceId(packingInvoiceNumber);
             int notCompletedCount = packingDao.countNotCompleted(orderId);
 
             // 4. 패킹 완료 메시지 작성, 전체 완료면 OUTBOUND도 20으로 변경 및 완료 메시지 작성
@@ -152,7 +152,7 @@ public class PackingServiceImp implements PackingService {
                 packingDao.updateOrderStateCode(orderId);
             }
             isSuccess = true;
-            message = notCompletedCount == 0 ? "송장 %s 패킹 완료 및 주문번호 %d 도 완료 처리되었습니다.".formatted(invoiceId, orderId) : "송장 %s 패킹 완료 처리되었습니다.".formatted(invoiceId);
+            message = notCompletedCount == 0 ? "송장 %s 및 주문번호 %d 패킹 완료 처리되었습니다.".formatted(packingInvoiceNumber, orderId) : "송장 %s 패킹 완료 처리되었습니다.".formatted(packingInvoiceNumber);
 
         } catch (Exception e) {
             log.info("PackingServiceImp completePacking error : {}", e.getMessage());

--- a/backend/src/main/java/cloud/weareithero/api/packing/service/PackingServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/service/PackingServiceImp.java
@@ -126,7 +126,7 @@ public class PackingServiceImp implements PackingService {
 
     @Transactional
     @Override
-    public ResponseDTO completePacking(int invoiceId) {
+    public ResponseDTO completePacking(String invoiceId) {
         boolean isSuccess = false;
         String message = null;
         try {
@@ -152,7 +152,7 @@ public class PackingServiceImp implements PackingService {
                 packingDao.updateOrderStateCode(orderId);
             }
             isSuccess = true;
-            message = notCompletedCount == 0 ? "송장번호 %d 패킹 완료 및 주문번호 %d 도 완료 처리되었습니다.".formatted(invoiceId, orderId) : "송장번호 %d 패킹 완료 처리되었습니다.".formatted(invoiceId);
+            message = notCompletedCount == 0 ? "송장 %s 패킹 완료 및 주문번호 %d 도 완료 처리되었습니다.".formatted(invoiceId, orderId) : "송장 %s 패킹 완료 처리되었습니다.".formatted(invoiceId);
 
         } catch (Exception e) {
             log.info("PackingServiceImp completePacking error : {}", e.getMessage());

--- a/backend/src/main/java/cloud/weareithero/api/packing/service/PackingServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/packing/service/PackingServiceImp.java
@@ -46,10 +46,10 @@ public class PackingServiceImp implements PackingService {
             data.put("list", list);
             data.put("pagination", pagination);
             isSuccess = true;
-            message = "Packing 탭 // 주문 목록 조회가 완료되었습니다.";
+            message = "Packing - 주문 목록 조회가 완료되었습니다.";
         } catch (Exception e) {
             log.info("PackingServiceImp findAll error : {}", e.getMessage());
-            message = "Packing 탭 // 주문 목록 조회에 실패했습니다.";
+            message = "Packing - 주문 목록 조회에 실패했습니다.";
         }
         return ResponseDTO.builder()
             .status(isSuccess)
@@ -75,10 +75,10 @@ public class PackingServiceImp implements PackingService {
             data.put("packingDetail", packingDetail);
             }
             isSuccess = true;
-            message = "Packing 탭 // 주문 상세 정보 조회가 완료되었습니다.";
+            message = "Packing - 주문 상세 정보 조회가 완료되었습니다.";
         } catch (Exception e) {
             log.info("PackingServiceImp findOne error : {}", e.getMessage());
-            message = "Packing 탭 // 주문 상세 정보 조회가 실패했습니다.";
+            message = "Packing - 주문 상세 정보 조회가 실패했습니다.";
         }
         return ResponseDTO.builder()
             .status(isSuccess)
@@ -106,20 +106,61 @@ public class PackingServiceImp implements PackingService {
                 }
                 if (size == PackingAddDTO.getPackingInvoice().size()) {
                     isSuccess = true;
-                    message = "Packing 탭 // 송장 %d건 생성이 완료되었습니다.".formatted(size);
+                    message = "Packing - 송장 %d건 생성이 완료되었습니다.".formatted(size);
                 } else {
                     isSuccess = false;
-                    message = "Packing 탭 // 패킹 송장 생성 일부 실패했습니다.";
+                    message = "Packing - 패킹 송장 생성 일부 실패했습니다.";
                 }
             }
         } catch (Exception e) {
             log.info("PackingServiceImp InsertPacking error : {}", e.getMessage());
             TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
-            message = "Packing 탭 // 패킹 송장 생성에 실패했습니다.";
+            message = "Packing - 패킹 송장 생성에 실패했습니다.";
         }
         return ResponseDTO.builder()
             .status(isSuccess)
             .data(data)
+            .message(message)
+            .build();
+    }
+
+    @Transactional
+    @Override
+    public ResponseDTO completePacking(int invoiceId) {
+        boolean isSuccess = false;
+        String message = null;
+        try {
+            // 1. 이미 완료된 패킹 송장인지 확인
+            int stateCode = packingDao.findPackingInvoiceStateCode(invoiceId);
+            if (stateCode == 20) {
+                message = "이미 패킹완료 처리된 송장입니다.";
+                return ResponseDTO.builder()
+                .status(isSuccess)
+                .message(message)
+                .build();
+            }
+
+            // 2. 패킹 송장 state_code 20(패킹완료)으로 변경
+            packingDao.updatePackingInvoiceStateCode(invoiceId);
+
+            // 3. 해당 주문의 전체 송장이 완료됐는지 확인
+            int orderId = packingDao.findOrderIdByInvoiceId(invoiceId);
+            int notCompletedCount = packingDao.countNotCompleted(orderId);
+
+            // 4. 패킹 완료 메시지 작성, 전체 완료면 OUTBOUND도 20으로 변경 및 완료 메시지 작성
+            if (notCompletedCount == 0) {
+                packingDao.updateOrderStateCode(orderId);
+            }
+            isSuccess = true;
+            message = notCompletedCount == 0 ? "송장번호 %d 패킹 완료 및 주문번호 %d 도 완료 처리되었습니다.".formatted(invoiceId, orderId) : "송장번호 %d 패킹 완료 처리되었습니다.".formatted(invoiceId);
+
+        } catch (Exception e) {
+            log.info("PackingServiceImp completePacking error : {}", e.getMessage());
+            TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+            message = "패킹 완료 처리에 실패했습니다.";
+        }
+        return ResponseDTO.builder()
+            .status(isSuccess)
             .message(message)
             .build();
     }

--- a/frontend/src/homes/App.jsx
+++ b/frontend/src/homes/App.jsx
@@ -39,7 +39,7 @@ function App() {
     <>
       <Routes>
       {/* PackingInvoicePage — 레이아웃 없이 독립 */}
-      <Route path='/packing/:invoiceId' element={<PackingInvoicePage />}/>
+      <Route path='/packing/:packingInvoiceNumber' element={<PackingInvoicePage />}/>
 
       {/* 나머지 — Header/Sidebar 포함 */}
       <Route path='/*' element={

--- a/frontend/src/homes/App.jsx
+++ b/frontend/src/homes/App.jsx
@@ -3,7 +3,7 @@ import { Routes, Route, useLocation } from "react-router";
 import Gate from '@gates/Gate.jsx';
 import NotFound from '@errors/NotFound.jsx';
 import Login from '@logins/Login.jsx';
-import Home from '@homes/main';
+// import Home from '@homes/main';
 import { useAuth } from '@hooks/AuthContext.jsx';
 
 import '@styles/common.css';
@@ -18,6 +18,7 @@ import OutHistory from '@homes/outbound/OutHistory.jsx';
 import Anomaly from '@homes/carbonEmission/Anomaly.jsx';
 import CarbonDashboard from '@homes/carbonEmission/CarbonDashboard.jsx';
 import Packing from '@homes/outbound/Packing.jsx';
+import PackingInvoicePage from '@homes/outbound/PackingInvoicePage.jsx';
 
 function App() {
   const location = useLocation();
@@ -33,28 +34,37 @@ function App() {
       </Routes>
     )
   }
-  // 주소가 바뀔 때마다 콘솔에 찍어봅니다.
+
   return (
     <>
-      <Header />
-      <div className="main-wrapper">
-          <Sidebar />
-          <div className="content-area">
-            <Routes>
-              {/* ⚠️ 맨 앞의 슬래시(/)를 모두 제거했습니다. */}
-              <Route path='/' element={<Main />}/>
-              <Route path='/asn' element={<Asn />}/>
-              <Route path='/inbound' element={<Inbound />}/>
-              <Route path='/order' element={<OutboundOrder />}/>
-              <Route path='/outbound' element={<Outbound />}/>
-              <Route path='/outhistory' element={<OutHistory />}/>
-              <Route path='/anomaly' element={<Anomaly />}/>
-              <Route path='/carbonemission' element={<CarbonDashboard />}/>
-              <Route path='/packing' element={<Packing />}/>
-              <Route path="*" element={ <NotFound />} />
-            </Routes>
+      <Routes>
+      {/* PackingInvoicePage — 레이아웃 없이 독립 */}
+      <Route path='/packing/:invoiceId' element={<PackingInvoicePage />}/>
+
+      {/* 나머지 — Header/Sidebar 포함 */}
+      <Route path='/*' element={
+        <>
+          <Header />
+          <div className="main-wrapper">
+            <Sidebar />
+            <div className="content-area">
+              <Routes>
+                <Route path='/' element={<Main />}/>
+                <Route path='/asn' element={<Asn />}/>
+                <Route path='/inbound' element={<Inbound />}/>
+                <Route path='/order' element={<OutboundOrder />}/>
+                <Route path='/outbound' element={<Outbound />}/>
+                <Route path='/outhistory' element={<OutHistory />}/>
+                <Route path='/anomaly' element={<Anomaly />}/>
+                <Route path='/carbonemission' element={<CarbonDashboard />}/>
+                <Route path='/packing' element={<Packing />}/>
+                <Route path="*" element={<NotFound />}/>
+              </Routes>
+            </div>
           </div>
-      </div>
+        </>
+      }/>
+    </Routes>
     </>
   )
 }

--- a/frontend/src/homes/outbound/Packing.jsx
+++ b/frontend/src/homes/outbound/Packing.jsx
@@ -93,7 +93,6 @@ const PackingTable = ({ orders, onRowClick, view }) => {
       case 20:
         return { text: '패킹완료', badgeClass: 'text-green bg-green-light' };
       default:
-        // 혹시 정의되지 않은 다른 코드가 올 경우를 대비한 예외 처리
         return { text: originalStep, badgeClass: 'text-muted bg-all-light' };
     }
   };
@@ -121,7 +120,6 @@ const PackingTable = ({ orders, onRowClick, view }) => {
                       <td>{order.partnerName}</td>
                       <td className="text-center text-green font-bold">{order.totalSets} 개</td>
                       <td className="text-center">{order.orderDate}</td>
-                      {/* 3. 변환된 텍스트와 클래스 적용 */}
                       <td className="text-center">
                         <span className={`table-badge ${currentStatus.badgeClass}`}>
                           {currentStatus.text}
@@ -201,7 +199,7 @@ const InvoiceSlider = ({ invoicePreviews, currentSlipIdx, prevSlip, nextSlip, cu
   }
 
   const currentInvoice = invoicePreviews[currentSlipIdx];
-  const qrUrl = `http://aigo.weareithero.cloud/packing/${currentInvoice.id}`;
+  const qrUrl = `${window.location.origin}packing/${currentInvoice.id}`;
 
   return (
     <div className="invoice-preview-card">

--- a/frontend/src/homes/outbound/Packing.jsx
+++ b/frontend/src/homes/outbound/Packing.jsx
@@ -199,7 +199,7 @@ const InvoiceSlider = ({ invoicePreviews, currentSlipIdx, prevSlip, nextSlip, cu
   }
 
   const currentInvoice = invoicePreviews[currentSlipIdx];
-  const qrUrl = `${window.location.origin}packing/${currentInvoice.id}`;
+  const qrUrl = `${window.location.origin}/packing/${currentInvoice.id}`;
 
   return (
     <div className="invoice-preview-card">

--- a/frontend/src/homes/outbound/Packing.jsx
+++ b/frontend/src/homes/outbound/Packing.jsx
@@ -199,7 +199,7 @@ const InvoiceSlider = ({ invoicePreviews, currentSlipIdx, prevSlip, nextSlip, cu
   }
 
   const currentInvoice = invoicePreviews[currentSlipIdx];
-  const qrUrl = `${window.location.origin}/packing/${currentInvoice.id}`;
+  const qrUrl = `${window.location.origin}/packing/${currentInvoice.packingInvoiceNumber}`;
 
   return (
     <div className="invoice-preview-card">

--- a/frontend/src/homes/outbound/PackingInvoicePage.jsx
+++ b/frontend/src/homes/outbound/PackingInvoicePage.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import { useDispatch } from 'react-redux';
+import { completePacking } from '@stores/packingSlice';
+
+const PackingInvoicePage = () => {
+    const { invoiceId } = useParams();
+    const dispatch = useDispatch();
+    const [result, setResult] = useState(null); // { status, message }
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        dispatch(completePacking({ invoiceId }))
+          .then((res) => {
+            setResult({
+              status: res.payload?.status,
+              message: res.payload?.message
+            });
+          })
+          .finally(() => setLoading(false));
+    }, []);
+
+    if (loading) {
+        return (
+            <div style={{ textAlign: 'center', padding: '2rem' }}>
+                <h2 style={{ color: 'green' }}>처리 중입니다...</h2>
+            </div>
+        );
+    };
+
+    return (
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+            {result?.status
+                ? <h2 style={{ color: 'green' }}>✅ {result.message}</h2>
+                : <h2 style={{ color: 'red' }}>❌ {result?.message}</h2>
+            }
+        </div>
+    );
+};
+
+export default PackingInvoicePage;

--- a/frontend/src/homes/outbound/PackingInvoicePage.jsx
+++ b/frontend/src/homes/outbound/PackingInvoicePage.jsx
@@ -4,13 +4,13 @@ import { useDispatch } from 'react-redux';
 import { completePacking } from '@stores/packingSlice';
 
 const PackingInvoicePage = () => {
-    const { invoiceId } = useParams();
+    const { packingInvoiceNumber } = useParams();
     const dispatch = useDispatch();
     const [result, setResult] = useState(null); // { status, message }
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        dispatch(completePacking({ invoiceId }))
+        dispatch(completePacking({ packingInvoiceNumber }))
           .then((res) => {
             setResult({
               status: res.payload?.status,

--- a/frontend/src/stores/packingSlice.js
+++ b/frontend/src/stores/packingSlice.js
@@ -1,5 +1,5 @@
 import { createSlice, createAsyncThunk, isPending, isRejected } from '@reduxjs/toolkit';
-import { POST, PUT } from "@utils/Network";
+import { POST, PUT, PATCH } from "@utils/Network";
 
 const initialState = {
   loading: false,
@@ -53,7 +53,7 @@ export const completePacking = createAsyncThunk(
   'packing/complete',
   async (credentials, { rejectWithValue }) => {
     try {
-      return await PATCH(`/packing/${credentials.invoiceId}`);
+      return await PATCH(`/packing/${credentials.packingInvoiceNumber}`);
     } catch (error) {
       return rejectWithValue(error.response?.data);
     }

--- a/frontend/src/stores/packingSlice.js
+++ b/frontend/src/stores/packingSlice.js
@@ -49,7 +49,18 @@ export const addPackingInvoice = createAsyncThunk(
   }
 );
 
-const packingAsyncActions = [getPacking, getPackingDetail, addPackingInvoice];
+export const completePacking = createAsyncThunk(
+  'packing/complete',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      return await PATCH(`/packing/${credentials.invoiceId}`);
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+const packingAsyncActions = [getPacking, getPackingDetail, addPackingInvoice, completePacking];
 
 const packingSlice = createSlice({
   name: 'packing',


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close  #69

## 📝 작업 내용
- [x] `PATCH /packing/{invoiceId}` API 구현 — 송장 단건 패킹완료 처리, 전체 송장 완료 시 주문 상태도 자동 완료 처리 (`@Transactional` 적용)
- [x] `PackingInvoicePage.jsx` 추가 — QR 스캔 시 진입하는 독립 페이지, Header/Sidebar 없이 렌더링되며 페이지 진입 즉시 PATCH API 호출 후 성공/실패 메시지 표시

## 💬 리뷰 포인트
- `invoiceId`가 `IVC-1-4-1` 형식의 VARCHAR라 PathVariable 정규식을 `[A-Za-z0-9-]+`로 설정했습니다.
- 전체 송장 완료 여부는 `countNotCompleted`로 확인 후 0이면 주문 행의 상태도 일괄 변경합니다.
- 이미 완료된 송장 재처리 시 롤백 없이 `status: false` 메시지로 반환합니다.