### PR TITLE
입고 - ASN 수정 및 추가

### DIFF
--- a/backend/src/main/java/cloud/weareithero/api/asn/AsnController.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/AsnController.java
@@ -1,6 +1,7 @@
 package cloud.weareithero.api.asn;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import cloud.weareithero.api.asn.dto.AsnAddDTO;
+import cloud.weareithero.api.asn.dto.AsnCompleteDTO;
 import cloud.weareithero.api.asn.dto.AsnRequestDTO;
 import cloud.weareithero.api.asn.service.AsnService;
 import cloud.weareithero.dto.ResponseDTO;
@@ -43,6 +45,12 @@ public class AsnController implements AsnControllerDocs {
   @Override
   public ResponseDTO findAllAsn() {
     return asnService.findAllAsn();
+  }
+
+  @PatchMapping
+  @Override
+  public ResponseDTO completeInbound(@RequestBody AsnCompleteDTO asnCompleteDTO) {
+      return asnService.completeInbound(asnCompleteDTO);
   }
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/asn/AsnControllerDocs.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/AsnControllerDocs.java
@@ -1,6 +1,7 @@
 package cloud.weareithero.api.asn;
 
 import cloud.weareithero.api.asn.dto.AsnAddDTO;
+import cloud.weareithero.api.asn.dto.AsnCompleteDTO;
 import cloud.weareithero.api.asn.dto.AsnRequestDTO;
 import cloud.weareithero.docs.ApiCommonErrors;
 import cloud.weareithero.docs.ApiCommonSuccess;
@@ -12,7 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "ASN 관리", description = "ASN 목록 조회 · ASN 생성 · ASN 상세 조회 API")
+@Tag(name = "ASN 관리", description = "ASN 목록 조회 · ASN 생성 · ASN 상세 조회 · 입고 완료 처리 API")
 public interface AsnControllerDocs {
 
   @Operation(summary = "입고 내역 조회", description = "ASN API")
@@ -40,5 +41,13 @@ public interface AsnControllerDocs {
   @ApiCommonSuccess
   @ApiCommonErrors
   public ResponseDTO findAllAsn();
+
+  @Operation(summary = "입고 완료 처리", description = "ASN API")
+  @ApiCommonSuccess
+  @ApiCommonErrors
+  public ResponseDTO completeInbound(
+      @RequestBody(content = @Content(schema = @Schema(implementation = AsnCompleteDTO.class), examples={
+          @ExampleObject(name = "입고 완료 예시", value = AsnResponseExamples.COMPLETE_ASN_DEFAULT, description = "입고번호와 실제 입고 시각을 입력합니다."),
+      })) AsnCompleteDTO asnCompleteDTO);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/asn/AsnResponseExamples.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/AsnResponseExamples.java
@@ -38,5 +38,11 @@ public interface AsnResponseExamples {
         "size": 20
       }
       """;
+  final String COMPLETE_ASN_DEFAULT = """
+      {
+        "asnId": 1,
+        "ata": "2026-06-15T14:30:00"
+      }
+      """;
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/asn/dao/AsnDao.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/dao/AsnDao.java
@@ -1,5 +1,6 @@
 package cloud.weareithero.api.asn.dao;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import cloud.weareithero.api.asn.dto.AsnDTO;
@@ -29,5 +30,9 @@ public interface AsnDao {
   public List<AsnWarehouseDTO> findByWarehouse();
 
   public List<AsnMaterialDTO> findByMaterial();
+
+  public int completeInbound(int asnId, LocalDateTime ata);
+
+  public int findStateCode(int asnId);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/asn/dao/AsnDaoImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/dao/AsnDaoImp.java
@@ -1,5 +1,6 @@
 package cloud.weareithero.api.asn.dao;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -67,4 +68,13 @@ public class AsnDaoImp implements AsnDao {
     return asnMapper.findByMaterial();
   }
 
+  @Override
+  public int completeInbound(int asnId, LocalDateTime ata) {
+    return asnMapper.completeInbound(asnId, ata);
+  }
+
+  @Override
+  public int findStateCode(int asnId) {
+    return asnMapper.findStateCode(asnId);
+  }
 }

--- a/backend/src/main/java/cloud/weareithero/api/asn/dao/AsnMapper.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/dao/AsnMapper.java
@@ -1,11 +1,14 @@
 package cloud.weareithero.api.asn.dao;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 import cloud.weareithero.api.asn.dto.AsnDTO;
 import cloud.weareithero.api.asn.dto.AsnMaterialDTO;
@@ -173,5 +176,18 @@ public interface AsnMapper {
       FROM `highgooh`.`MATERIAL_MASTER`
       """)
   public List<AsnMaterialDTO> findByMaterial();
+
+  // 입고 완료 처리 - state_code 변경, ata(실제입고시각) 기록
+  @Update("""
+      UPDATE `INBOUND` 
+        SET `state_code` = 5, 
+            `ata` = #{ata}
+        WHERE `id` = #{asnId}
+      """)
+  public int completeInbound(@Param("asnId") int asnId, @Param("ata") LocalDateTime ata);
+
+  // 입고 상태 검색
+  @Select("SELECT `state_code` FROM `INBOUND` WHERE `id` = #{asnId}")
+  public int findStateCode(int asnId);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/asn/dto/AsnCompleteDTO.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/dto/AsnCompleteDTO.java
@@ -1,0 +1,13 @@
+package cloud.weareithero.api.asn.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AsnCompleteDTO {
+    private int asnId;
+    private String ata;
+}

--- a/backend/src/main/java/cloud/weareithero/api/asn/service/AsnService.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/service/AsnService.java
@@ -1,6 +1,7 @@
 package cloud.weareithero.api.asn.service;
 
 import cloud.weareithero.api.asn.dto.AsnAddDTO;
+import cloud.weareithero.api.asn.dto.AsnCompleteDTO;
 import cloud.weareithero.api.asn.dto.AsnRequestDTO;
 import cloud.weareithero.dto.ResponseDTO;
 
@@ -13,5 +14,7 @@ public interface AsnService {
   public ResponseDTO add(AsnAddDTO asnAddDTO);
 
   public ResponseDTO findAllAsn();
+
+  public ResponseDTO completeInbound(AsnCompleteDTO asnCompleteDTO);
 
 }

--- a/backend/src/main/java/cloud/weareithero/api/asn/service/AsnServiceImp.java
+++ b/backend/src/main/java/cloud/weareithero/api/asn/service/AsnServiceImp.java
@@ -1,14 +1,18 @@
 package cloud.weareithero.api.asn.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
 
 import cloud.weareithero.api.asn.dao.AsnDao;
 import cloud.weareithero.api.asn.dto.AsnAddDTO;
+import cloud.weareithero.api.asn.dto.AsnCompleteDTO;
 import cloud.weareithero.api.asn.dto.AsnDTO;
 import cloud.weareithero.api.asn.dto.AsnMaterialDTO;
 import cloud.weareithero.api.asn.dto.AsnOrderMaterialDTO;
@@ -158,6 +162,39 @@ public class AsnServiceImp implements AsnService {
         .data(request)
         .message(message)
         .build();
+  }
+
+  @Transactional
+  @Override
+  public ResponseDTO completeInbound(AsnCompleteDTO asnCompleteDTO) {
+    boolean isSuccess = false;
+    String message = null;
+    try {
+        // 1. state_code 확인
+        int stateCode = asnDao.findStateCode(asnCompleteDTO.getAsnId());
+        if (stateCode != 4) {
+            message = "입고예정 상태의 ASN만 완료 처리할 수 있습니다.";
+            return ResponseDTO.builder().status(false).message(message).build();
+        }
+        // 2. 입고 완료 처리
+        LocalDateTime ata = LocalDateTime.parse(asnCompleteDTO.getAta());
+        int result = asnDao.completeInbound(asnCompleteDTO.getAsnId(), ata);
+        if (result > 0) {
+            isSuccess = true;
+            message = "입고 완료 처리되었습니다.";
+        } else {
+            message = "입고 완료 처리에 실패했습니다.";
+        }
+    } catch (Exception e) {
+        log.info("AsnServiceImp completeInbound error : {}", e.getMessage());
+        TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+        message = "입고 완료 처리에 실패했습니다.";
+    }
+    return ResponseDTO.builder()
+        .status(isSuccess)
+        .message(message)
+        .build();
+    
   }
 
 }

--- a/frontend/src/components/UI/AsnModal.jsx
+++ b/frontend/src/components/UI/AsnModal.jsx
@@ -2,8 +2,9 @@ import { useState, useEffect } from 'react';
 import { GET, POST, PUT } from "@utils/Network";
 import '@styles/asn.css';
 import { useDispatch, useSelector } from "react-redux";
-import { closeAsnModal, addAsnModal } from '@stores/asnSlice';
+import { closeAsnModal, addAsnModal, completeAsn } from '@stores/asnSlice';
 import { showDefaultAlert } from "@components/UI/ServiceAlert";
+import { getNow } from '@stores/date';
 
 /**
  * AsnModal
@@ -28,13 +29,11 @@ const AsnModal = () => {
   const warehouses = useSelector((state) => state.asn.modal.warehouses);
   const materials = useSelector((state) => state.asn.modal.materials);
 
-  const [asn, setAsn] = useState({
-    partnerCompany: 0,
-    eta: '',
-    warehouse: 0,
-    vehicleNumber: ''
-  });
+  const [asn, setAsn] = useState({ partnerCompany: 0, eta: '', warehouse: 0, vehicleNumber: '' });
   const [asnMaterials, setAsnMaterials] = useState([]);
+
+  const [isAtaModal, setIsAtaModal] = useState(false);
+  const [ata, setAta] = useState('');
 
   /* ── 상세 모드: initialData 로 폼 채우기 ── */
   useEffect(() => {
@@ -205,11 +204,58 @@ const AsnModal = () => {
             <button className="btn-pop-cancel" onClick={setModal}>
               {isDetail ? '닫기' : '취소'}
             </button>
+            {/* 입고예정일 때만 버튼 노출 */}
+            {isDetail && initialData?.asn?.step === '입고예정' && (
+              <button className="btn-pop-submit" onClick={() => {
+                setAta(getNow());
+                setIsAtaModal(true);
+              }}>
+                입고 완료 처리
+              </button>
+            )}
             {!isDetail && (
-              <button className="btn-pop-submit" onClick={addAsn}>ASN 등록</button>)}
+              <button className="btn-pop-submit" onClick={addAsn}>ASN 등록</button>
+            )}
           </div>
         </div>
       </div>
+
+      {/* ATA 입력 모달 */}
+      {isAtaModal && (
+        <div className="modal-overlay2 active" onClick={() => setIsAtaModal(false)}>
+          <div className="modal-window" style={{ width: '400px' }} onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">
+              <h3>실제 입고 시각 입력</h3>
+              <button className="modal-close-btn" onClick={() => setIsAtaModal(false)}>&times;</button>
+            </div>
+            <div className="modal-body">
+              <div className="input-box">
+                <label>실제 입고 시각 (ATA)</label>
+                <input
+                  type="datetime-local"
+                  className="filter-date-input"
+                  value={ata}
+                  onChange={(e) => setAta(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button className="btn-pop-cancel" onClick={() => setIsAtaModal(false)}>취소</button>
+              <button className="btn-pop-submit" onClick={() => {
+                if (!ata) {
+                  showDefaultAlert("오류", "입고 시각을 입력해주세요.", "error");
+                  return;
+                }
+                dispatch(completeAsn({
+                  asnId: initialData.asn.asnId,
+                  ata: ata + ':00' // "2026-06-15T14:30:00" 형식
+                }));
+                setIsAtaModal(false);
+              }}>확인</button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 };

--- a/frontend/src/components/UI/AsnModal.jsx
+++ b/frontend/src/components/UI/AsnModal.jsx
@@ -4,7 +4,7 @@ import '@styles/asn.css';
 import { useDispatch, useSelector } from "react-redux";
 import { closeAsnModal, addAsnModal } from '@stores/asnSlice';
 import { showDefaultAlert } from "@components/UI/ServiceAlert";
- 
+
 /**
  * AsnModal
  * @param {boolean}  isModal   - 모달 표시 여부
@@ -27,7 +27,7 @@ const AsnModal = () => {
   const partnerCompany = useSelector((state) => state.asn.modal.partnerCompany);
   const warehouses = useSelector((state) => state.asn.modal.warehouses);
   const materials = useSelector((state) => state.asn.modal.materials);
- 
+
   const [asn, setAsn] = useState({
     partnerCompany: 0,
     eta: '',
@@ -35,34 +35,35 @@ const AsnModal = () => {
     vehicleNumber: ''
   });
   const [asnMaterials, setAsnMaterials] = useState([]);
- 
+
   /* ── 상세 모드: initialData 로 폼 채우기 ── */
   useEffect(() => {
     if (isDetail && initialData) {
       const { asn, items } = initialData; // { asn: {...}, items: [...] }
       setAsn({
-        partnerCompany: asn.partnerId     ?? 0,
-        eta:            asn.eta           ?? '',
-        warehouse:      asn.warehouseId   ?? 0,
-        vehicleNumber:  asn.vehicleNumber ?? ''
+        partnerCompany: asn.partnerId ?? 0,
+        eta: asn.eta ?? '',
+        warehouse: asn.warehouseId ?? 0,
+        vehicleNumber: asn.vehicleNumber ?? ''
       });
       setAsnMaterials(
         (items ?? []).map(item => ({
-          itemNo:   item.itemNo   ?? 0,
-          weight:   item.weight   ?? 0,
+          itemNo: item.itemNo ?? 0,
+          itemName: item.itemName ?? '',
+          weight: item.weight ?? 0,
           diameter: item.diameter ?? 0
         }))
       );
     }
   }, [isDetail, initialData]);
- 
+
   /* ── 이벤트 핸들러 ── */
   const onChangeEvent = (e) => {
     if (isDetail) return; // 상세 모드는 읽기 전용
     const { name, value } = e.target;
     setAsn(prev => ({ ...prev, [name]: value }));
   };
- 
+
   const onChangeTableEvent = (e, index) => {
     if (isDetail) return;
     const { name, value } = e.target;
@@ -70,56 +71,52 @@ const AsnModal = () => {
       prev.map((item, i) => i === index ? { ...item, [name]: Number(value) } : item)
     );
   };
- 
+
   const onDeleteRow = (index) => {
     if (isDetail) return;
     setAsnMaterials(prev => prev.filter((_, i) => i !== index));
   };
- 
+
   const addAsnMaterial = () => {
     setAsnMaterials(prev => [...prev, { itemNo: 0, weight: 0, diameter: 0 }]);
   };
- 
+
   /* ── 등록 제출 ── */
   const addAsn = () => {
-    if (asn.partnerCompany === 0)  { showDefaultAlert("오류", "공급사명을 선택하세요.", "error"); return; }
-    if (asn.eta === '')            { showDefaultAlert("오류", "입고 예정 날짜을 선택해주세요.", "error"); return; }
-    if (asn.warehouse === 0)       { showDefaultAlert("오류", "입고 창고을 선택해주세요.", "error"); return; }
- 
+    if (asn.partnerCompany === 0) { showDefaultAlert("오류", "공급사명을 선택하세요.", "error"); return; }
+    if (asn.eta === '') { showDefaultAlert("오류", "입고 예정 날짜을 선택해주세요.", "error"); return; }
+    if (asn.warehouse === 0) { showDefaultAlert("오류", "입고 창고을 선택해주세요.", "error"); return; }
+
     for (const material of asnMaterials) {
-      if (material.itemNo   === 0) { showdefaultAlert("오류", "품목을 선택해주세요.", "error"); return; }
-      if (material.weight   === 0) { showDefaultAlert("오류", "품목 무게을 입력해주세요.", "error"); return; }
+      if (material.itemNo === 0) { showdefaultAlert("오류", "품목을 선택해주세요.", "error"); return; }
+      if (material.weight === 0) { showDefaultAlert("오류", "품목 무게을 입력해주세요.", "error"); return; }
       if (material.diameter === 0) { showDefaultAlert("오류", "지름을 입력해주세요.", "error"); return; }
     }
 
     if (asnMaterials.length === 0) { showDefaultAlert("오류", "입고 품목을 추가해주세요.", "error"); return; }
- 
+
     const params = {
       partnerCompanyId: asn.partnerCompany,
-      warehouseId:      asn.warehouse,
-      eta:              asn.eta,
-      items:            asnMaterials
+      warehouseId: asn.warehouse,
+      eta: asn.eta,
+      items: asnMaterials
     };
- 
+
     dispatch(addAsnModal(params));
   };
- 
+
   /* ── 렌더링 ── */
   return (
     <>
-      <div
-        className={isModal ? 'modal-overlay active' : 'modal-overlay'}
-        onClick={setModal}
-      />
+      <div className={isModal ? 'modal-overlay active' : 'modal-overlay'} onClick={setModal} />
       <div className={isModal ? 'modal-overlay2 active' : 'modal-overlay'}>
         <div className="modal-window">
- 
           {/* 헤더 */}
           <div className="modal-header">
             <h3>{isDetail ? '사전입고 통지(ASN) 상세' : '사전입고 통지(ASN) 등록'}</h3>
             <button className="modal-close-btn" onClick={setModal}>&times;</button>
           </div>
- 
+
           {/* 바디 */}
           <div className="modal-body">
             <div className="popup-section">
@@ -127,53 +124,36 @@ const AsnModal = () => {
               <div className="form-grid-4">
                 <div className="input-box">
                   <label>공급사명</label>
-                  <select
-                    name="partnerCompany"
-                    value={asn.partnerCompany}
-                    onChange={onChangeEvent}
-                    disabled={isDetail}
-                  >
-                    <option value={0}>선택</option>
-                    {partnerCompany?.map((v, i) =>
-                      <option key={i} value={v.id}>{v.name}</option>
-                    )}
-                  </select>
+                  {isDetail
+                    ? <input type="text" className="filter-date-input" value={initialData?.asn?.partnerName ?? ''} readOnly />
+                    : <select name="partnerCompany" value={asn.partnerCompany} onChange={onChangeEvent}>
+                      <option value={0}>선택</option>
+                      {partnerCompany?.map((v, i) => <option key={i} value={v.id}>{v.name}</option>)}
+                    </select>
+                  }
                 </div>
                 <div className="input-box">
                   <label>입고 예정일</label>
-                  <input
-                    type="date"
-                    className="filter-date-input"
-                    name="eta"
-                    value={asn.eta}
-                    onChange={onChangeEvent}
-                    readOnly={isDetail}
-                  />
+                  <input type="date" className="filter-date-input" name="eta" value={asn.eta} onChange={onChangeEvent} readOnly={isDetail} />
                 </div>
               </div>
               <div className="input-box">
                 <label>입고 창고</label>
-                <select
-                  name="warehouse"
-                  value={asn.warehouse}
-                  onChange={onChangeEvent}
-                  disabled={isDetail}
-                >
-                  <option value={0}>선택하세요</option>
-                  {warehouses?.map((v, i) =>
-                    <option key={i} value={v.id}>{v.name}</option>
-                  )}
-                </select>
+                {isDetail
+                  ? <input type="text" className="filter-date-input" value={initialData?.asn?.warehouseName ?? ''} readOnly />
+                  : <select name="warehouse" value={asn.warehouse} onChange={onChangeEvent}>
+                    <option value={0}>선택하세요</option>
+                    {warehouses?.map((v, i) => <option key={i} value={v.id}>{v.name}</option>)}
+                  </select>
+                }
               </div>
             </div>
- 
+
             <div className="popup-section" style={{ marginTop: '1.5rem' }}>
               <div className="section-header-flex">
                 <h4 className="sub-title">품목 정보</h4>
                 {!isDetail && (
-                  <button type="button" className="btn-secondary-sm" onClick={addAsnMaterial}>
-                    + 품목 추가
-                  </button>
+                  <button type="button" className="btn-secondary-sm" onClick={addAsnMaterial}>+ 품목 추가</button>
                 )}
               </div>
               <div className="table-responsive" style={{ maxHeight: '250px', overflowY: 'auto' }}>
@@ -192,48 +172,24 @@ const AsnModal = () => {
                       <tr key={i}>
                         <td className="text-center">{i + 1}</td>
                         <td>
-                          <select
-                            className="table-inner-input highlight-field"
-                            name="itemNo"
-                            value={v.itemNo}
-                            onChange={e => onChangeTableEvent(e, i)}
-                            disabled={isDetail}
-                          >
-                            <option value={0}>선택하세요</option>
-                            {materials?.map((vv, ii) =>
-                              <option key={ii} value={vv.id}>{vv.alloyType}</option>
-                            )}
-                          </select>
+                          {isDetail
+                            ? <input type="text" className="table-inner-input" value={v.itemName ?? ''} readOnly />
+                            : <select className="table-inner-input highlight-field" name="itemNo" value={v.itemNo} onChange={e => onChangeTableEvent(e, i)} disabled={isDetail}>
+                              <option value={0}>선택하세요</option>
+                              {materials?.map((vv, ii) => <option key={ii} value={vv.id}>{vv.alloyType}</option>)}
+                            </select>
+                          }
                         </td>
                         <td>
-                          <input
-                            type="number"
-                            className="table-inner-input text-right highlight-field"
-                            name="weight"
-                            value={v.weight}
-                            onChange={e => onChangeTableEvent(e, i)}
-                            readOnly={isDetail}
-                          />
+                          <input type="number" className="table-inner-input text-right highlight-field" name="weight" value={v.weight} onChange={e => onChangeTableEvent(e, i)} readOnly={isDetail} />
                         </td>
                         <td>
-                          <input
-                            type="number"
-                            className="table-inner-input highlight-field"
-                            name="diameter"
-                            value={v.diameter}
-                            onChange={e => onChangeTableEvent(e, i)}
-                            readOnly={isDetail}
-                          />
+                          <input type="number" className="table-inner-input highlight-field" name="diameter"
+                            value={v.diameter} onChange={e => onChangeTableEvent(e, i)} readOnly={isDetail} />
                         </td>
                         {!isDetail && (
                           <td className="text-center">
-                            <button
-                              type="button"
-                              className="btn-delete-row"
-                              onClick={() => onDeleteRow(i)}
-                            >
-                              &times;
-                            </button>
+                            <button type="button" className="btn-delete-row" onClick={() => onDeleteRow(i)}>&times;</button>
                           </td>
                         )}
                       </tr>
@@ -243,23 +199,19 @@ const AsnModal = () => {
               </div>
             </div>
           </div>
- 
+
           {/* 푸터 */}
           <div className="modal-footer">
             <button className="btn-pop-cancel" onClick={setModal}>
               {isDetail ? '닫기' : '취소'}
             </button>
             {!isDetail && (
-              <button className="btn-pop-submit" onClick={addAsn}>
-                ASN 등록
-              </button>
-            )}
+              <button className="btn-pop-submit" onClick={addAsn}>ASN 등록</button>)}
           </div>
- 
         </div>
       </div>
     </>
   );
 };
- 
+
 export default AsnModal;

--- a/frontend/src/components/UI/AsnModal.jsx
+++ b/frontend/src/components/UI/AsnModal.jsx
@@ -3,6 +3,7 @@ import { GET, POST, PUT } from "@utils/Network";
 import '@styles/asn.css';
 import { useDispatch, useSelector } from "react-redux";
 import { closeAsnModal, addAsnModal } from '@stores/asnSlice';
+import { showDefaultAlert } from "@components/UI/ServiceAlert";
  
 /**
  * AsnModal
@@ -81,15 +82,17 @@ const AsnModal = () => {
  
   /* ── 등록 제출 ── */
   const addAsn = () => {
-    if (asn.partnerCompany === 0)  { alert("공급사명 선택하세요.");       return; }
-    if (asn.eta === '')            { alert("입고 예정 날짜를 선택하세요."); return; }
-    if (asn.warehouse === 0)       { alert("입고 창고를 선택하세요.");      return; }
+    if (asn.partnerCompany === 0)  { showDefaultAlert("오류", "공급사명을 선택하세요.", "error"); return; }
+    if (asn.eta === '')            { showDefaultAlert("오류", "입고 예정 날짜을 선택해주세요.", "error"); return; }
+    if (asn.warehouse === 0)       { showDefaultAlert("오류", "입고 창고을 선택해주세요.", "error"); return; }
  
     for (const material of asnMaterials) {
-      if (material.itemNo   === 0) { alert("품목 등록이 되어 있지 않습니다.");    return; }
-      if (material.weight   === 0) { alert("품목 무게가 등록되어 있지 않습니다."); return; }
-      if (material.diameter === 0) { alert("지름이 등록되어 있지 않습니다.");      return; }
+      if (material.itemNo   === 0) { showdefaultAlert("오류", "품목을 선택해주세요.", "error"); return; }
+      if (material.weight   === 0) { showDefaultAlert("오류", "품목 무게을 입력해주세요.", "error"); return; }
+      if (material.diameter === 0) { showDefaultAlert("오류", "지름을 입력해주세요.", "error"); return; }
     }
+
+    if (asnMaterials.length === 0) { showDefaultAlert("오류", "입고 품목을 추가해주세요.", "error"); return; }
  
     const params = {
       partnerCompanyId: asn.partnerCompany,

--- a/frontend/src/homes/inbound/Asn.jsx
+++ b/frontend/src/homes/inbound/Asn.jsx
@@ -4,6 +4,7 @@ import AsnModal from '@components/UI/AsnModal';
 import { useDispatch, useSelector } from "react-redux";
 import { getAsn, getAsnDetail, getAsnModal, openAsnModal, setPage } from '@stores/asnSlice';
 import { getFirstDay, getLastDayOfMonth, addOneDay } from '@stores/date';
+import { showDefaultAlert } from "@components/UI/ServiceAlert";
 
 const Asn = () => {
   const dispatch = useDispatch();
@@ -63,7 +64,7 @@ const Asn = () => {
     }
 
     if (params.orderStart && !params.orderEnd) {
-      alert("주문 기간이 필요합니다.");
+      showDefaultAlert("오류", "주문 기간이 필요합니다.", "error");
       return;
     }
 
@@ -184,25 +185,27 @@ const Asn = () => {
                 </tr>
               </thead>
               <tbody>
-                {list?.map(v => (
-                  <tr key={v.asnId}>
-                    <td>{v.orderDate}</td>
-                    <td>
-                      <a className="text-link" style={{ cursor: 'pointer' }} onClick={() => openAsnDetailModal(v.asnId)}>
-                        {v.asnId}
-                      </a>
-                    </td>
-                    <td>{v.partnerName}</td>
-                    <td>{v.warehouseName}</td>
-                    <td>{v.eta}</td>
-                    <td>{v.itemCount}건</td>
-                    <td>
-                      <span className={v.step === '입고예정' ? 'status-badge ready' : 'status-badge complete'}>
-                        {v.step}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
+                {list.length === 0 ? (<tr>
+                  <td colSpan={7} className="text-center" style={{ padding: '2rem', color: 'gray' }}>조회된 데이터가 없습니다.</td></tr>) :
+                  list?.map(v => (
+                    <tr key={v.asnId}>
+                      <td>{v.orderDate}</td>
+                      <td>
+                        <a className="text-link" style={{ cursor: 'pointer' }} onClick={() => openAsnDetailModal(v.asnId)}>
+                          {v.asnId}
+                        </a>
+                      </td>
+                      <td>{v.partnerName}</td>
+                      <td>{v.warehouseName}</td>
+                      <td>{v.eta}</td>
+                      <td>{v.itemCount}건</td>
+                      <td>
+                        <span className={v.step === '입고예정' ? 'status-badge ready' : 'status-badge complete'}>
+                          {v.step}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
               </tbody>
             </table>
           </div>

--- a/frontend/src/homes/outbound/Packing.jsx
+++ b/frontend/src/homes/outbound/Packing.jsx
@@ -14,7 +14,7 @@ const PackingSummary = ({ summary, isCurrentMonth }) => {
   return (
     <div className="order-summary-grid">
       <div className="summary-card-item">
-        <div className="card-info-left"><span className="summary-label">당월</span><span className="summary-value">{summary.total}<small>건</small></span></div>
+        <div className="card-info-left"><span className="summary-label">전체</span><span className="summary-value">{summary.total}<small>건</small></span></div>
         <div className="card-trend-right"><span className="status-badge bg-all-light text-muted">{trendText}</span></div>
       </div>
       <div className="summary-card-item">

--- a/frontend/src/stores/asnSlice.js
+++ b/frontend/src/stores/asnSlice.js
@@ -15,7 +15,7 @@ const initialState = {
     page: 1,
     totalCount: 0,
     totalPages: 0,
-    size: 10
+    size: 20
   },
   modal: {
     partnerCompany: [],
@@ -130,7 +130,8 @@ const asnSlice = createSlice({
       .addCase(addAsnModal.fulfilled, (state, action) => {
         const res = action.payload;
         if (res.status === true) {
-          alert("사전입고 통지(ASN)가 등록되었습니다.");
+          // alert("사전입고 통지(ASN)가 등록되었습니다.");
+          showDefaultAlert("등록 완료", "사전입고 통지(ASN)가 등록되었습니다.", "success");
           state.isModal = false;
         }else {
           state.error = res.message;

--- a/frontend/src/stores/asnSlice.js
+++ b/frontend/src/stores/asnSlice.js
@@ -130,7 +130,6 @@ const asnSlice = createSlice({
       .addCase(addAsnModal.fulfilled, (state, action) => {
         const res = action.payload;
         if (res.status === true) {
-          // alert("사전입고 통지(ASN)가 등록되었습니다.");
           showDefaultAlert("등록 완료", "사전입고 통지(ASN)가 등록되었습니다.", "success");
           state.isModal = false;
         }else {

--- a/frontend/src/stores/asnSlice.js
+++ b/frontend/src/stores/asnSlice.js
@@ -72,7 +72,18 @@ export const addAsnModal = createAsyncThunk(
   }
 );
 
-const asnAsyncActions = [getAsn, getAsnDetail, getAsnModal, addAsnModal];
+export const completeAsn = createAsyncThunk(
+  'asn/complete',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      return await PATCH('/asn', credentials);
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+const asnAsyncActions = [getAsn, getAsnDetail, getAsnModal, addAsnModal, completeAsn];
 
 const asnSlice = createSlice({
   name: 'asn',
@@ -111,7 +122,7 @@ const asnSlice = createSlice({
           state.detailData = res.data;
           state.isModal = true;
           state.modalMode = 'detail';
-        }else {
+        } else {
           state.error = res.message;
         }
         state.loading = false;
@@ -120,9 +131,9 @@ const asnSlice = createSlice({
         const res = action.payload;
         if (res.status === true) {
           state.modal.partnerCompany = res.data.suppliers;
-          state.modal.warehouses= res.data.warehouses;
+          state.modal.warehouses = res.data.warehouses;
           state.modal.materials = res.data.materials;
-        }else {
+        } else {
           state.error = res.message;
         }
         state.loading = false;
@@ -132,28 +143,38 @@ const asnSlice = createSlice({
         if (res.status === true) {
           showDefaultAlert("등록 완료", "사전입고 통지(ASN)가 등록되었습니다.", "success");
           state.isModal = false;
-        }else {
+        } else {
           state.error = res.message;
+        }
+        state.loading = false;
+      })
+      .addCase(completeAsn.fulfilled, (state, action) => {
+        const res = action.payload;
+        if (res.status === true) {
+          showDefaultAlert("완료", res.message, "success");
+          state.isModal = false;
+        } else {
+          showDefaultAlert("오류", res.message, "error");
         }
         state.loading = false;
       });
 
-    builder
+  builder
       .addMatcher(
-        isPending(...asnAsyncActions), 
-        (state) => {
-          state.loading = true;
-          state.error = null;
-        }
-      )
-      .addMatcher(
-        isRejected(...asnAsyncActions), 
-        (state, action) => {
-          state.loading = false;
-          state.error = action.payload || action.error.message || '알 수 없는 에러가 발생했습니다.';
-        }
-      );
-  }
+    isPending(...asnAsyncActions),
+    (state) => {
+      state.loading = true;
+      state.error = null;
+    }
+  )
+    .addMatcher(
+      isRejected(...asnAsyncActions),
+      (state, action) => {
+        state.loading = false;
+        state.error = action.payload || action.error.message || '알 수 없는 에러가 발생했습니다.';
+      }
+    );
+}
 });
 
 export const { openAsnModal, closeAsnModal, setPage } = asnSlice.actions;

--- a/frontend/src/stores/authSlice.js
+++ b/frontend/src/stores/authSlice.js
@@ -74,9 +74,9 @@ const authSlice = createSlice({
       .addCase(loginUser.fulfilled, (state, action) => {
         const res = action.payload;
         if (res.status === true) {
+          showDefaultAlert("로그인 완료", "회원 인증이 완료되었습니다.", "success");
           state.isAuthReady = true;
           state.redirectUrl = "/";
-          // showDefaultAlert("로그인 완료", "회원 인증이 완료되었습니다.", "success");
         } else {
           state.isAuthReady = false;
           state.redirectUrl = "/";

--- a/frontend/src/stores/authSlice.js
+++ b/frontend/src/stores/authSlice.js
@@ -3,14 +3,11 @@ import { GET, POST, PUT, PATCH, DELETE } from "@utils/Network";
 import { encodeJson, safeJsonParse } from "@utils/Base64";
 import { showDefaultAlert } from "@components/UI/ServiceAlert";
 
-// export const getAuthRedirectUrl = type => type ? "/companyselect" : "/serviceselect";
-
 const initialState = {
   isAuthReady: false,
   redirectUrl: "/",
   name: "",
   role: [],
-  // companies: safeJsonParse(localStorage.getItem("companies"), []),
   loading: false,
   error: null,
 };
@@ -61,18 +58,13 @@ const authSlice = createSlice({
     builder
       .addCase(checkUser.fulfilled, (state, action) => {
         const res = action.payload;
-        // console.log(res);
         if (res.status === true) {
           state.name = res.data?.name;
           const roles = res.data?.role.split(/\s*,\s*/);
           state.role = roles;
-          // const storedCompanies = safeJsonParse(localStorage.getItem("companies"), []);
-          // state.companies = storedCompanies;
           state.isAuthReady = true;
-          // state.redirectUrl = getAuthRedirectUrl(storedCompanies.length > 0);
           state.redirectUrl = "/";
         } else {
-          // localStorage.removeItem("companies");
           state.isAuthReady = false;
           state.redirectUrl = "/";
         }
@@ -82,18 +74,12 @@ const authSlice = createSlice({
       .addCase(loginUser.fulfilled, (state, action) => {
         const res = action.payload;
         if (res.status === true) {
-          // const storedCompanies = res.data.companies;
-          // localStorage.setItem("companies", encodeJson(storedCompanies));
-          // state.companies = storedCompanies;
           state.isAuthReady = true;
-          // state.redirectUrl = getAuthRedirectUrl(storedCompanies.length > 0);
           state.redirectUrl = "/";
           // showDefaultAlert("로그인 완료", "회원 인증이 완료되었습니다.", "success");
         } else {
-          // localStorage.removeItem("companies");
           state.isAuthReady = false;
           state.redirectUrl = "/";
-          // showDefaultAlert("로그인 실패", "이메일 또는 비밀번호가 일치하지 않습니다.", "error");
         }
         state.loading = false;
       });
@@ -101,10 +87,8 @@ const authSlice = createSlice({
       .addCase(logoutUser.fulfilled, (state, action) => {
         const res = action.payload;
         if (res.status === true) {
-          // localStorage.removeItem('companies');
           state.isAuthReady = false;
           state.redirectUrl = "/";
-          // state.companies = [];
           state.loading = false;
           showDefaultAlert("로그아웃 완료", "회원 인증이 만료되었습니다.", "success");
         } else {

--- a/frontend/src/stores/date.js
+++ b/frontend/src/stores/date.js
@@ -54,4 +54,13 @@ export const addOneDay = (dateStr) => {
     return `${year}-${month}-${day}`;
 };
 
+export const getNow = () => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const date = String(now.getDate()).padStart(2, '0');
+    const hours = String(now.getHours()).padStart(2, '0');
+    const minutes = String(now.getMinutes()).padStart(2, '0');
 
+    return `${year}-${month}-${date}T${hours}:${minutes}`; // "2026-06-15T14:30"
+};

--- a/frontend/src/styles/asn.css
+++ b/frontend/src/styles/asn.css
@@ -85,7 +85,7 @@
     width: 100%;
     height: 100%;
     background-color: rgba(0, 0, 0, 0.4);
-    z-index: 2000;
+    z-index: 300;
     justify-content: center;
     align-items: center;
 }
@@ -95,7 +95,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    z-index: 2001;
+    z-index: 301;
 }
 
 /* 모달이 활성화되었을 때 중앙 정렬 노출 */


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#79

## 📝 작업 내용
- [x] ASN 상세 모달 수정 — 공급사명, 입고 창고, 품목명을 `getAsnModal` 호출 없이 상세 조회 응답값(`partnerName`, `warehouseName`, `itemName`)으로 직접 표시하도록 변경
- [x] `PATCH /asn` API 구현 — 입고예정(state_code=4) 여부 검증 후 입고완료(state_code=5) 처리 및 실제 입고 시각(ATA) 기록, `@Transactional` 적용
- [x] AsnModal에 입고 완료 처리 버튼 추가 — `step === '입고예정'`일 때만 노출
- [x] ATA 입력 모달 추가 — 현재 시각을 기본값으로 하는 `datetime-local` 입력 후 확인 시 PATCH 호출
- [x] `date.js`에 `getNow()` 함수 추가 — 현재 날짜+시각을 `datetime-local` 형식(`YYYY-MM-DDTHH:mm`)으로 반환

## 💬 리뷰 포인트
- 상세 조회 시 응답값만으로 모달이 채워집니다.
- 백엔드에서 state_code가 입고예정(4)이 아닌 경우 `status: false`로 반환하여 프런트에서 알림 처리합니다.
- ATA는 `LocalDateTime.parse()`로 처리하며 `"YYYY-MM-DDTHH:mm:ss"` 형식으로 전달됩니다.