### PR TITLE
입고 - ASN / inbound 페이지 수정

### DIFF
--- a/backend/src/main/java/cloud/weareithero/config/SecurityConfig.java
+++ b/backend/src/main/java/cloud/weareithero/config/SecurityConfig.java
@@ -1,10 +1,13 @@
 package cloud.weareithero.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -15,8 +18,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import cloud.weareithero.config.auth.JweAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 
-import java.util.List;
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -26,7 +27,8 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf(csrf -> csrf.disable());
+    // http.csrf(csrf -> csrf.disable());
+    http.csrf(AbstractHttpConfigurer::disable);
     http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
     http.authorizeHttpRequests(authorize -> {
       authorize.requestMatchers("/docs", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll();

--- a/frontend/src/homes/inbound/Asn.jsx
+++ b/frontend/src/homes/inbound/Asn.jsx
@@ -41,57 +41,44 @@ const Asn = () => {
     dispatch(getAsnDetail(params));
   };
 
-  /* ── 검색 / 목록 조회 ── */
   const searchEvent = (e) => {
     e.preventDefault();
     if (page === 1) getData(); else dispatch(setPage(1));
   };
 
   const getData = () => {
+    const startVal = orderStartRef.current?.value || "";
+    const endVal = orderEndRef.current?.value || "";
+
+    if ((startVal !== "" && endVal === "") || (startVal === "" && endVal !== "")) {
+      showDefaultAlert("오류", "입고일자 검색을 완성하거나 초기화 후 검색해주세요.", "error");
+      return;
+    }
+
     const params = { page, size };
 
-    if (asnRef.current?.value) params.asnId = asnRef.current.value;
+    if (asnRef.current !== null) params.asnId = asnRef.current.value;
 
-    if (orderStartRef.current?.value) {
-      params.orderStart = orderStartRef.current.value;
-      setFirstDate(params.orderStart)
+    if (startVal !== "") {
+      params.orderStart = startVal;
+      setFirstDate(startVal);
     }
 
-    if (orderEndRef.current?.value) {
-      params.orderEnd = addOneDay(orderEndRef.current.value);
-      setEndDate(orderEndRef.current.value)
-    }
-
-    if (params.orderStart && !params.orderEnd) {
-      showDefaultAlert("오류", "주문 기간이 필요합니다.", "error");
-      return;
+    if (endVal !== "") {
+      params.orderEnd = addOneDay(endVal);
+      setEndDate(endVal);
     }
 
     dispatch(getAsn(params));
   };
 
   useEffect(() => {
-    if (!isModal) {
-      getData();
-    }
+    if (!isModal) getData();
   }, [page, isModal]);
-
-
-  // useEffect(() => {
-
-  //   // input 엘리먼트에 초기값 주입
-  //   if (orderStartRef.current) orderStartRef.current.value = getFirstDay();
-  //   if (orderEndRef.current) orderEndRef.current.value = getLastDayOfMonth();
-
-  //   // 초기 데이터 로드 호출
-  //   getData();
-  // }, []);
-
 
   // 팬딩
   // if (loading) return <></>;
 
-  /* ── 렌더링 ── */
   return (
     <div id="asn-page">
       <div id="asn-management-page" className="page-content active">

--- a/frontend/src/homes/inbound/Asn.jsx
+++ b/frontend/src/homes/inbound/Asn.jsx
@@ -25,16 +25,15 @@ const Asn = () => {
   const totalPages = useSelector((state) => state.asn.view.totalPages);
   const size = useSelector((state) => state.asn.view.size);
 
-  const [firstDate, setFirstDate] = useState(null);
-  const [endDate, setEndDate] = useState(null);
+  const [firstDate, setFirstDate] = useState(getFirstDay());
+  const [endDate, setEndDate] = useState(getLastDayOfMonth());
 
 
   const resetResearch = () => {
     if (orderStartRef.current) orderStartRef.current.value = getFirstDay();
     if (orderEndRef.current) orderEndRef.current.value = getLastDayOfMonth();
-    if (asnRef.current) asnRef.current.value = null;
-    // 초기 데이터 로드 호출
-    getData();
+    if (asnRef.current) asnRef.current.value = "";
+    if (page === 1) getData(); else dispatch(setPage(1));
   }
 
   const openAsnDetailModal = async (id) => {
@@ -45,7 +44,7 @@ const Asn = () => {
   /* ── 검색 / 목록 조회 ── */
   const searchEvent = (e) => {
     e.preventDefault();
-    getData();
+    if (page === 1) getData(); else dispatch(setPage(1));
   };
 
   const getData = () => {
@@ -78,15 +77,15 @@ const Asn = () => {
   }, [page, isModal]);
 
 
-  useEffect(() => {
+  // useEffect(() => {
 
-    // input 엘리먼트에 초기값 주입
-    if (orderStartRef.current) orderStartRef.current.value = getFirstDay();
-    if (orderEndRef.current) orderEndRef.current.value = getLastDayOfMonth();
+  //   // input 엘리먼트에 초기값 주입
+  //   if (orderStartRef.current) orderStartRef.current.value = getFirstDay();
+  //   if (orderEndRef.current) orderEndRef.current.value = getLastDayOfMonth();
 
-    // 초기 데이터 로드 호출
-    getData();
-  }, []);
+  //   // 초기 데이터 로드 호출
+  //   getData();
+  // }, []);
 
 
   // 팬딩
@@ -149,9 +148,9 @@ const Asn = () => {
             <div className="filter-group group-date-range">
               <label>주문 기간</label>
               <div className="date-range-container">
-                <input type="date" className="filter-control" ref={orderStartRef} />
+                <input type="date" className="filter-control" ref={orderStartRef} defaultValue={getFirstDay()} />
                 <span className="date-separator">~</span>
-                <input type="date" className="filter-control" ref={orderEndRef} />
+                <input type="date" className="filter-control" ref={orderEndRef} defaultValue={getLastDayOfMonth()} />
               </div>
             </div>
             <div className="filter-group">

--- a/frontend/src/homes/inbound/Asn.jsx
+++ b/frontend/src/homes/inbound/Asn.jsx
@@ -185,8 +185,7 @@ const Asn = () => {
                 </tr>
               </thead>
               <tbody>
-                {list.length === 0 ? (<tr>
-                  <td colSpan={7} className="text-center" style={{ padding: '2rem', color: 'gray' }}>조회된 데이터가 없습니다.</td></tr>) :
+                {list.length === 0 ? (<tr><td colSpan={7} className="text-center" style={{ padding: '2rem', color: 'gray' }}>조회된 데이터가 없습니다.</td></tr>) :
                   list?.map(v => (
                     <tr key={v.asnId}>
                       <td>{v.orderDate}</td>

--- a/frontend/src/homes/inbound/Inbound.jsx
+++ b/frontend/src/homes/inbound/Inbound.jsx
@@ -1,20 +1,24 @@
 import { useState, useEffect, useRef } from 'react';
 import { POST } from "@utils/Network";
 import '@styles/inbound.css';
+import { useDispatch, useSelector } from 'react-redux';
+import { getInbound, getInboundDetail, setPage, closeInboundModal } from '@stores/inboundSlice';
 import { getFirstDay, getLastDayOfMonth, addOneDay } from '@stores/date';
 import { showDefaultAlert } from "@components/UI/ServiceAlert";
 
-const InboundModal = ({ detailData, isModal, setModal }) => {
+// 1. 내부 모달 컴포넌트도 리덕스 액션을 바라보도록 수정
+const InboundModal = ({ detailData, isModal }) => {
+    const dispatch = useDispatch();
     const inbound = detailData?.inbound;
     const items = detailData?.items || [];
 
     return (
         <>
-            <div className={isModal ? "modal-overlay active" : "modal-overlay"} id="asnDetailModal" onClick={(e) => { if (e.target.id === 'asnDetailModal') setModal(false); }}>
+            <div className={isModal ? "modal-overlay active" : "modal-overlay"} id="asnDetailModal" onClick={(e) => { if (e.target.id === 'asnDetailModal') dispatch(closeInboundModal()); }}>
                 <div className="modal-container modal-window" style={{ maxWidth: '1000px', width: '90%' }}>
                     <div className="modal-header">
                         <h3>ASN 상세 명세 조회</h3>
-                        <button className="modal-close-btn" onClick={() => setModal(false)}>&times;</button>
+                        <button className="modal-close-btn" onClick={() => dispatch(closeInboundModal())}>&times;</button>
                     </div>
 
                     <div className="modal-body" style={{ padding: '1.5rem' }}>
@@ -27,15 +31,13 @@ const InboundModal = ({ detailData, isModal, setModal }) => {
                                     style={{ backgroundColor: '#e2e8f0', color: '#4a5568', cursor: 'not-allowed', width: '100%', height: '38px', padding: '0.5rem', border: '1px solid var(--border-color)', borderRadius: '4px', boxSizing: 'border-box' }} />
                             </div>
                             <div className="form-group-item">
-                                <label
-                                    style={{ display: 'block', fontSize: '0.85rem', fontWeight: 700, color: 'var(--text-dark)', marginBottom: '0.5rem', textAlign: 'left' }}>공급사명</label>
+                                <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 700, color: 'var(--text-dark)', marginBottom: '0.5rem', textAlign: 'left' }}>공급사명</label>
                                 <input type="text" id="detail_supplier" className="table-inner-input" readOnly
                                     value={inbound?.partnerName || ''}
                                     style={{ backgroundColor: '#e2e8f0', color: '#4a5568', cursor: 'not-allowed', width: '100%', height: '38px', padding: '0.5rem', border: '1px solid var(--border-color)', borderRadius: '4px', boxSizing: 'border-box' }} />
                             </div>
                             <div className="form-group-item">
-                                <label
-                                    style={{ display: 'block', fontSize: '0.85rem', fontWeight: 700, color: 'var(--text-dark)', marginBottom: '0.5rem', textAlign: 'left' }}>진행상태</label>
+                                <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 700, color: 'var(--text-dark)', marginBottom: '0.5rem', textAlign: 'left' }}>진행상태</label>
                                 <select id="detail_asn_status" className="table-inner-input" disabled value="입고완료"
                                     style={{ width: '100%', height: '38px', padding: '0.5rem', border: '1px solid var(--border-color)', borderRadius: '4px', boxSizing: 'border-box', backgroundColor: '#e2e8f0', color: '#4a5568', cursor: 'not-allowed', WebkitAppearance: 'none', MozAppearance: 'none', appearance: 'none' }}>
                                     <option value="출고완료">출고완료</option>
@@ -48,8 +50,7 @@ const InboundModal = ({ detailData, isModal, setModal }) => {
                         </div>
 
                         <div className="sheet-tab-content active" style={{ borderTop: 'none' }}>
-                            <div className="excel-table-wrapper"
-                                style={{ maxHeight: '300px', overflowY: 'auto', border: '1px solid var(--border-color)', borderTop: 'none' }}>
+                            <div className="excel-table-wrapper" style={{ maxHeight: '300px', overflowY: 'auto', border: '1px solid var(--border-color)', borderTop: 'none' }}>
                                 <table className="excel-styled-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
                                     <thead>
                                         <tr>
@@ -60,16 +61,14 @@ const InboundModal = ({ detailData, isModal, setModal }) => {
                                         </tr>
                                     </thead>
                                     <tbody id="detailAsnTableBody">
-                                        {
-                                            items.map((item, index) => (
-                                                <tr key={index}>
-                                                    <td style={{ border: '1px solid var(--border-color)', padding: '0.5rem', fontSize: '0.85rem', textAlign: 'center' }}>{index + 1}</td>
-                                                    <td style={{ border: '1px solid var(--border-color)', padding: '0.5rem', fontSize: '0.85rem', textAlign: 'left' }}>{item.alloyType}</td>
-                                                    <td style={{ border: '1px solid var(--border-color)', padding: '0.5rem', fontSize: '0.85rem', textAlign: 'left' }}>{item.itemName}</td>
-                                                    <td style={{ border: '1px solid var(--border-color)', padding: '0.5rem', fontSize: '0.85rem', textAlign: 'right' }}>{item.weight?.toLocaleString()}</td>
-                                                </tr>
-                                            ))
-                                        }
+                                        {items.map((item, index) => (
+                                            <tr key={index}>
+                                                <td style={{ border: '1px solid var(--border-color)', padding: '0.5rem', fontSize: '0.85rem', textAlign: 'center' }}>{index + 1}</td>
+                                                <td style={{ border: '1px solid var(--border-color)', padding: '0.5rem', fontSize: '0.85rem', textAlign: 'left' }}>{item.alloyType}</td>
+                                                <td style={{ border: '1px solid var(--border-color)', padding: '0.5rem', fontSize: '0.85rem', textAlign: 'left' }}>{item.itemName}</td>
+                                                <td style={{ border: '1px solid var(--border-color)', padding: '0.5rem', fontSize: '0.85rem', textAlign: 'right' }}>{item.weight?.toLocaleString()}</td>
+                                            </tr>
+                                        ))}
                                     </tbody>
                                 </table>
                             </div>
@@ -77,8 +76,7 @@ const InboundModal = ({ detailData, isModal, setModal }) => {
                     </div>
 
                     <div className="modal-footer" style={{ padding: '1rem 1.5rem', backgroundColor: '#f8fafc', borderTop: '1px solid var(--border-color)', display: 'flex', justifyContent: 'flex-end' }}>
-                        <button type="button" className="btn-pop-cancel" onClick={() => setModal(false)}
-                            style={{ minWidth: '120px', backgroundColor: '#64748b', color: 'white', border: 'none', padding: '0.6rem', borderRadius: '4px', fontWeight: 600, cursor: 'pointer' }}>닫기</button>
+                        <button type="button" className="btn-pop-cancel" onClick={() => dispatch(closeInboundModal())} style={{ minWidth: '120px', backgroundColor: '#64748b', color: 'white', border: 'none', padding: '0.6rem', borderRadius: '4px', fontWeight: 600, cursor: 'pointer' }}>닫기</button>
                     </div>
                 </div>
             </div>
@@ -87,89 +85,74 @@ const InboundModal = ({ detailData, isModal, setModal }) => {
 };
 
 const Inbound = () => {
+    const dispatch = useDispatch();
+
     const orderStartRef = useRef(null);
     const orderEndRef = useRef(null);
     const asnRef = useRef(null);
 
-    const [isModal, setModal] = useState(false);
-    const [list, setList] = useState([]);
-    const [page, setPage] = useState(1);
-    const [totalCount, setTotalCount] = useState(0);
-    const [totalPages, setTotalPages] = useState(0);
-    const [size, setSize] = useState(10);
-    const [detailData, setDetailData] = useState(null);
-
+    const isModal = useSelector((state) => state.inbound.isModal);
+    const list = useSelector((state) => state.inbound.view.list);
+    const page = useSelector((state) => state.inbound.view.page);
+    const totalCount = useSelector((state) => state.inbound.view.totalCount);
+    const totalPages = useSelector((state) => state.inbound.view.totalPages);
+    const size = useSelector((state) => state.inbound.view.size);
+    const detailData = useSelector((state) => state.inbound.detailData);
 
     const [firstDate, setFirstDate] = useState(null);
     const [endDate, setEndDate] = useState(null);
 
-    const openDetailModal = (id) => {
-        POST(`/inbound/${id}`).then(res => {
-            if (res.status === true) {
-                setDetailData(res.data);
-                setModal(true);
-            }
-        });
+    const openDetailModal = (asnId) => {
+        const params = { asnId };
+        dispatch(getInboundDetail(params));
     };
 
     const searchEvent = (e) => {
         e.preventDefault();
-        getData();
-    }
-
+        if (page === 1) getData(); else dispatch(setPage(1));
+    };
 
     const resetResearch = () => {
         if (orderStartRef.current) orderStartRef.current.value = getFirstDay();
         if (orderEndRef.current) orderEndRef.current.value = getLastDayOfMonth();
-        if (asnRef.current) asnRef.current.value = null;
-        // 초기 데이터 로드 호출
-        getData();
-    }
+        if (asnRef.current) asnRef.current.value = "";
+        if (page === 1) getData(); else dispatch(setPage(1));
+    };
 
     const getData = () => {
         const params = { page, size };
 
-        if (asnRef.current !== null) {
+        if (asnRef.current?.value) {
             params.asnId = asnRef.current.value;
         }
 
         if (orderStartRef.current?.value) {
             params.orderStart = orderStartRef.current.value;
-            setFirstDate(params.orderStart)
+            setFirstDate(params.orderStart);
         }
 
         if (orderEndRef.current?.value) {
             params.orderEnd = addOneDay(orderEndRef.current.value);
-            setEndDate(orderEndRef.current.value)
+            setEndDate(orderEndRef.current.value);
         }
 
-        if (params?.orderStart !== "" && params?.orderEnd === "") {
+        if (params.orderStart === "" && params.orderEnd !== "") {
             showDefaultAlert("오류", "입고일자 검색을 완성하거나 초기화 후 검색해주세요.", "error");
             return;
         }
 
-        POST("/inbound", params).then(res => {
-            setList(res.data.list);
-            setPage(res.data.pagination.page);
-            setTotalCount(res.data.pagination.totalCount);
-            setTotalPages(res.data.pagination.totalPages);
-        });
-    }
+        dispatch(getInbound(params));
+    };
 
     useEffect(() => {
-
-        // input 엘리먼트에 초기값 주입
         if (orderStartRef.current) orderStartRef.current.value = getFirstDay();
         if (orderEndRef.current) orderEndRef.current.value = getLastDayOfMonth();
-
-        // 초기 데이터 로드 호출
         getData();
-    }, []); 
+    }, []);
 
     useEffect(() => {
-        getData()
+        if (page !== 1) getData();
     }, [page]);
-
 
     return (
         <div id="inbound-page">
@@ -205,7 +188,7 @@ const Inbound = () => {
                 <div className="table-responsive">
                     <div className="inhistory-btn-group">
                         <button type="button" className="btn-filter-reset">엑셀 다운로드</button>
-                        <button type="submit" className="btn-filter-search" onClick={getData} >새로고침</button>
+                        <button type="button" className="btn-filter-search" onClick={getData}>새로고침</button>
                     </div>
                     <table className="history-data-table">
                         <thead>
@@ -217,16 +200,20 @@ const Inbound = () => {
                             </tr>
                         </thead>
                         <tbody id="historyTableBody">
-                            {
-                                list?.map((v, i) =>
+                            {list.length === 0 ? (
+                                <tr>
+                                    <td colSpan={4} className="text-center" style={{ padding: '2rem', color: 'gray' }}>조회된 데이터가 없습니다.</td>
+                                </tr>
+                            ) : (
+                                list?.map((v, i) => (
                                     <tr key={i}>
                                         <td className="text-center">{v.ata}</td>
-                                        <td className="font-bold text-link" onClick={() => openDetailModal(v.asnId)}>{v.asnId}</td>
+                                        <td className="font-bold text-link" style={{ cursor: 'pointer' }} onClick={() => openDetailModal(v.asnId)}>{v.asnId}</td>
                                         <td>{v.partnerName}</td>
                                         <td className="text-center">{v.warehouseName}</td>
                                     </tr>
-                                )
-                            }
+                                ))
+                            )}
                         </tbody>
                     </table>
                 </div>
@@ -237,25 +224,22 @@ const Inbound = () => {
                     </div>
 
                     <div className="pagination-buttons">
-                        <button type="button" className="btn-page" title="처음 페이지" onClick={() => setPage(1)} disabled={page <= 1}>&lt;&lt;</button>
-                        <button type="button" className="btn-page" title="이전 블록" onClick={() => setPage(page - 1)} disabled={page <= 1}>&lt;</button>
-                        {
-                            Array.from({ length: totalPages }).map((v, i) => {
-                                const index = i + 1;
-                                return (
-                                    <button key={i} type="button" className={page == index ? 'btn-page-num active' : 'btn-page-num'} onClick={() => setPage(index)}>{index}</button>
-                                )
-                            }
+                        <button type="button" className="btn-page" title="처음 페이지" onClick={() => dispatch(setPage(1))} disabled={page <= 1}>&lt;&lt;</button>
+                        <button type="button" className="btn-page" title="이전 블록" onClick={() => dispatch(setPage(page - 1))} disabled={page <= 1}>&lt;</button>
+                        {Array.from({ length: totalPages }).map((v, i) => {
+                            const index = i + 1;
+                            return (
+                                <button key={i} type="button" className={page == index ? 'btn-page-num active' : 'btn-page-num'} onClick={() => dispatch(setPage(index))}>{index}</button>
                             )
-                        }
-                        <button type="button" className="btn-page" title="다음 블록" onClick={() => setPage(page + 1)} disabled={page == totalPages}>&gt;</button>
-                        <button type="button" className="btn-page" title="끝 페이지" onClick={() => setPage(totalPages)} disabled={page == totalPages}>&gt;&gt;</button>
+                        })}
+                        <button type="button" className="btn-page" title="다음 블록" onClick={() => dispatch(setPage(page + 1))} disabled={page == totalPages}>&gt;</button>
+                        <button type="button" className="btn-page" title="끝 페이지" onClick={() => dispatch(setPage(totalPages))} disabled={page == totalPages}>&gt;&gt;</button>
                     </div>
                 </div>
 
             </div>
 
-            {isModal && <InboundModal detailData={detailData} isModal={isModal} setModal={setModal} />}
+            {isModal && <InboundModal detailData={detailData} isModal={isModal} />}
         </div>
     )
 }

--- a/frontend/src/homes/inbound/Inbound.jsx
+++ b/frontend/src/homes/inbound/Inbound.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { POST } from "@utils/Network";
 import '@styles/inbound.css';
 import { getFirstDay, getLastDayOfMonth, addOneDay } from '@stores/date';
+import { showDefaultAlert } from "@components/UI/ServiceAlert";
 
 const InboundModal = ({ detailData, isModal, setModal }) => {
     const inbound = detailData?.inbound;
@@ -143,7 +144,7 @@ const Inbound = () => {
         }
 
         if (params?.orderStart !== "" && params?.orderEnd === "") {
-            alert("입고일자 검색을 완성하거나 초기화 후 검색해주세요.");
+            showDefaultAlert("오류", "입고일자 검색을 완성하거나 초기화 후 검색해주세요.", "error");
             return;
         }
 

--- a/frontend/src/homes/inbound/Inbound.jsx
+++ b/frontend/src/homes/inbound/Inbound.jsx
@@ -6,7 +6,6 @@ import { getInbound, getInboundDetail, setPage, closeInboundModal } from '@store
 import { getFirstDay, getLastDayOfMonth, addOneDay } from '@stores/date';
 import { showDefaultAlert } from "@components/UI/ServiceAlert";
 
-// 1. 내부 모달 컴포넌트도 리덕스 액션을 바라보도록 수정
 const InboundModal = ({ detailData, isModal }) => {
     const dispatch = useDispatch();
     const inbound = detailData?.inbound;
@@ -120,39 +119,34 @@ const Inbound = () => {
     };
 
     const getData = () => {
-        const params = { page, size };
+        const startVal = orderStartRef.current?.value || "";
+        const endVal = orderEndRef.current?.value || "";
 
-        if (asnRef.current?.value) {
-            params.asnId = asnRef.current.value;
-        }
-
-        if (orderStartRef.current?.value) {
-            params.orderStart = orderStartRef.current.value;
-            setFirstDate(params.orderStart);
-        }
-
-        if (orderEndRef.current?.value) {
-            params.orderEnd = addOneDay(orderEndRef.current.value);
-            setEndDate(orderEndRef.current.value);
-        }
-
-        if (params.orderStart === "" && params.orderEnd !== "") {
+        if ((startVal !== "" && endVal === "") || (startVal === "" && endVal !== "")) {
             showDefaultAlert("오류", "입고일자 검색을 완성하거나 초기화 후 검색해주세요.", "error");
             return;
+        }
+
+        const params = { page, size };
+
+        if (asnRef.current !== null) params.asnId = asnRef.current.value;
+
+        if (startVal !== "") {
+            params.orderStart = startVal;
+            setFirstDate(startVal);
+        }
+
+        if (endVal !== "") {
+            params.orderEnd = addOneDay(endVal);
+            setEndDate(endVal);
         }
 
         dispatch(getInbound(params));
     };
 
     useEffect(() => {
-        if (orderStartRef.current) orderStartRef.current.value = getFirstDay();
-        if (orderEndRef.current) orderEndRef.current.value = getLastDayOfMonth();
-        getData();
-    }, []);
-
-    useEffect(() => {
-        if (page !== 1) getData();
-    }, [page]);
+        if (!isModal) getData();
+    }, [page, isModal]);
 
     return (
         <div id="inbound-page">
@@ -165,9 +159,9 @@ const Inbound = () => {
                     <div className="filter-group group-date-range">
                         <label>입고일자 검색</label>
                         <div className="date-range-container">
-                            <input type="date" id="search_start_date" className="filter-control" ref={orderStartRef} />
+                            <input type="date" id="search_start_date" className="filter-control" ref={orderStartRef} defaultValue={getFirstDay()} />
                             <span className="date-separator">~</span>
-                            <input type="date" id="search_end_date" className="filter-control" ref={orderEndRef} />
+                            <input type="date" id="search_end_date" className="filter-control" ref={orderEndRef} defaultValue={getLastDayOfMonth()} />
                         </div>
                     </div>
                     <div className="filter-group">

--- a/frontend/src/stores/InboundSlice.js
+++ b/frontend/src/stores/InboundSlice.js
@@ -1,0 +1,100 @@
+import { createSlice, createAsyncThunk, isPending, isRejected } from '@reduxjs/toolkit';
+import { GET, POST, PUT, PATCH, DELETE } from "@utils/Network";
+import { showDefaultAlert } from "@components/UI/ServiceAlert";
+
+const initialState = {
+  loading: false,
+  error: null,
+  isModal: false,
+  detailData: null,
+  view: {
+    list: [],
+    page: 1,
+    totalCount: 0,
+    totalPages: 0,
+    size: 20
+  }
+};
+
+export const getInbound = createAsyncThunk(
+  'inbound/list',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      const response = await POST('/inbound', credentials);
+      return response;
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+export const getInboundDetail = createAsyncThunk(
+  'inbound/detail',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      const response = await POST(`/inbound/${id}`);
+      return response;
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+const inboundAsyncActions = [getInbound, getInboundDetail];
+
+const inboundSlice = createSlice({
+  name: 'inbound',
+  initialState,
+  reducers: {
+    closeInboundModal: (state, action) => {
+      state.isModal = false;
+    },
+    setPage: (state, action) => {
+      state.view.page = action.payload;
+    }
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(getInbound.fulfilled, (state, action) => {
+        const res = action.payload;
+        if (res.status === true) {
+          state.view.list = res.data.list;
+          state.view.page = res.data.pagination.page;
+          state.view.totalCount = res.data.pagination.totalCount;
+          state.view.totalPages = res.data.pagination.totalPages;
+        } else {
+          state.error = res.message;
+        }
+        state.loading = false;
+      })
+      .addCase(getInboundDetail.fulfilled, (state, action) => {
+        const res = action.payload;
+        if (res.status === true) {
+          state.detailData = res.data;
+          state.isModal = true;
+        } else {
+          state.error = res.message;
+        }
+        state.loading = false;
+      });
+
+    builder
+      .addMatcher(
+        isPending(...inboundAsyncActions),
+        (state) => {
+          state.loading = true;
+          state.error = null;
+        }
+      )
+      .addMatcher(
+        isRejected(...inboundAsyncActions),
+        (state, action) => {
+          state.loading = false;
+          state.error = action.payload || action.error.message || '알 수 없는 에러가 발생했습니다.';
+        }
+      );
+  }
+});
+
+export const { closeInboundModal, setPage } = inboundSlice.actions;
+export default inboundSlice.reducer;

--- a/frontend/src/stores/InboundSlice.js
+++ b/frontend/src/stores/InboundSlice.js
@@ -32,7 +32,7 @@ export const getInboundDetail = createAsyncThunk(
   'inbound/detail',
   async (credentials, { rejectWithValue }) => {
     try {
-      const response = await POST(`/inbound/${id}`);
+      const response = await POST(`/inbound/${credentials.asnId}`);
       return response;
     } catch (error) {
       return rejectWithValue(error.response?.data);

--- a/frontend/src/stores/index.js
+++ b/frontend/src/stores/index.js
@@ -1,17 +1,17 @@
 import { configureStore } from "@reduxjs/toolkit";
-import authReducer from '@stores/authSlice'
-import asnReducer from '@stores/asnSlice'
-import orderReducer from '@stores/orderSlice'
-import packingReducer from '@stores/packingSlice'
+import authReducer from '@stores/authSlice';
+import asnReducer from '@stores/asnSlice';
+import inboundReducer from '@stores/inboundSlice';
+import orderReducer from '@stores/orderSlice';
+import packingReducer from '@stores/packingSlice';
 import outboundReducer from '@stores/outboundSlice';
-import outboundHistoryReducer from '@stores/outboundHistorySlice'
-
-
+import outboundHistoryReducer from '@stores/outboundHistorySlice';
 
 const store = configureStore({
     reducer:{
         auth: authReducer,
         asn: asnReducer,
+        inbound: inboundReducer,
         order: orderReducer,
         packing: packingReducer,
         outbound: outboundReducer,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #79 

## 📝 작업 내용
- [x] **검색 필터 날짜 예외 처리 로직 수정 (Asn, Inbound 공통)**
  - 시작일이나 종료일 중 하나만 삭제하고 조회 시, 자바스크립트 Falsy 특성(`""`과 `undefined` 비교 오류)으로 인해 조건문을 우회하여 백엔드로 전체 조회가 요청되던 버그 수정
  - `ref` 값을 변수로 사전 할당하여 둘 중 하나만 비어있는 케이스(`(startVal !== "" && endVal === "") || (startVal === "" && endVal !== "")`)를 정확하게 교차 검증하도록 변경
- [x] **Inbound 페이지네이션 및 useEffect 구조 개선**
  - 다른 페이지에서 1페이지로 돌아올 때 `if (page !== 1)` 조건문에 걸려 서버 요청이 차단되고 목록이 갱신되지 않던 페이징 에러 해결
  - 컴포넌트 마운트 직후 `Ref.current.value`를 직접 조작하여 날짜를 주입하던 부하를 줄이기 위해, input 태그 자체에 `defaultValue` 적용
  - 복잡하게 쪼개져 있던 기존 `useEffect` 구조를 걷어내고, `Asn.jsx` 구조를 벤치마킹하여 `[page, isModal]` 상태 변화를 감지하는 단일 `useEffect` 통로(선언적 동기화)로 리팩토링

## 💬 리뷰 포인트
- 날짜 검색창에서 시작일 또는 종료일 중 하나만 지운 채 '조회하기'를 눌렀을 때, 에러 알림창이 정상적으로 뜨고 검색이 차단되는지 확인해 주세요.
- Inbound 페이지에서 페이지네이션 버튼을 통해 페이지를 이동할 때(특히 1페이지로 다시 돌아올 때) 데이터가 멈추는 현상 없이 유기적으로 잘 갱신되는지 확인 부탁드립니다.